### PR TITLE
fix: apply mouse mode on reattach to existing tmux session

### DIFF
--- a/.changeset/0006-fix-mouse-mode-reattach.md
+++ b/.changeset/0006-fix-mouse-mode-reattach.md
@@ -1,0 +1,5 @@
+---
+"claude-remote-notify": patch
+---
+
+Fix mouse mode not applied when reattaching to existing tmux session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix touchpad scroll cycling through prompt history instead of conversation history
   - Enable tmux mouse mode for claude-remote sessions
   - Add text selection hint (Option+drag on Mac) to session startup output
+  - Fix mouse mode not applied when reattaching to existing session
 
 ### Security
 - Fix command injection in telegram-listener.py - removed shell=True, use shlex for arg parsing, whitelist safe env vars

--- a/claude-remote
+++ b/claude-remote
@@ -310,9 +310,6 @@ start_session() {
         # Create tmux session with environment variables
         tmux new-session -d -s "$tmux_name" -e "CLAUDE_SESSION=$session" -e "TMUX_SESSION=$tmux_name"
 
-        # Enable mouse mode for proper touchpad scrolling (scrollback navigation)
-        tmux set-option -t "$tmux_name" mouse on
-        
         # Create a wrapper script that runs Claude and cleans up on exit
         # Use umask subshell to ensure file is created with restricted permissions
         local cleanup_script="$CLAUDE_HOME/cleanup-$session.sh"
@@ -368,7 +365,10 @@ CLEANUP
     else
         info "tmux session already exists"
     fi
-    
+
+    # Enable mouse mode for proper touchpad scrolling (always apply, even on reattach)
+    tmux set-option -t "$tmux_name" mouse on
+
     # Start listener if not running
     if ! listener_running "$session"; then
         info "Starting Telegram listener..."

--- a/tests/test_claude_remote.sh
+++ b/tests/test_claude_remote.sh
@@ -150,19 +150,20 @@ test_mouse_mode_enabled_in_script() {
         "Script contains mouse mode enable command"
 }
 
-test_mouse_mode_after_session_creation() {
+test_mouse_mode_after_session_block() {
     echo ""
-    echo "Testing: mouse mode command follows session creation"
+    echo "Testing: mouse mode set after session create/attach block (applies to both cases)"
 
     local script_content
     script_content=$(cat "$PROJECT_DIR/claude-remote")
 
-    # Extract lines around tmux new-session
+    # Mouse mode should be set after the fi (end of session create/attach block)
+    # and before the listener start, so it applies whether session is new or existing
     local context
-    context=$(echo "$script_content" | grep -A 5 "tmux new-session -d -s")
+    context=$(echo "$script_content" | grep -A 5 "tmux session already exists")
 
     assert_contains "$context" "mouse on" \
-        "Mouse mode enabled after session creation"
+        "Mouse mode enabled after session block (works for new and existing sessions)"
 }
 
 test_text_select_hint_present() {
@@ -485,7 +486,7 @@ run_all_tests() {
 
     # Script content tests
     test_mouse_mode_enabled_in_script
-    test_mouse_mode_after_session_creation
+    test_mouse_mode_after_session_block
     test_text_select_hint_present
     test_text_select_hint_near_detach_hint
     test_mouse_mode_comment_present


### PR DESCRIPTION
## Summary
- Fix mouse mode not applied when reattaching to existing tmux session
- Previous fix only set mouse mode on new session creation, not reattach

## Test plan
- [x] All 19 tests passing, 100% coverage
- [ ] Verify scroll works after reattaching to existing session