### PR TITLE
fix: /notify on not working after /notify off via Telegram

### DIFF
--- a/.changeset/0009-fix-notify-on-after-off.md
+++ b/.changeset/0009-fix-notify-on-after-off.md
@@ -1,0 +1,10 @@
+---
+"claude-remote-notify": patch
+---
+
+Fix `/notify on` not working after `/notify off` via Telegram
+
+- Handle `/notify on` and `/notify off` commands directly in Python listener
+- Eliminates subprocess environment issues that prevented flag file creation
+- Listener now sends confirmation messages directly (previously relied on shell script)
+- Add comprehensive unit tests for notify on/off toggle scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Added
 - `/clear` and `/compact` commands via Telegram to manage Claude context remotely
-- Unit tests for command handlers (30 tests, 97% coverage)
+- Unit tests for command handlers (62 tests covering notify on/off toggle scenarios)
 - Telegram message formatting: strip ANSI codes, convert tables to bullet points for readability
 - `format_for_telegram()` function in lib/common.sh for terminal output transformation
 
 ### Fixed
+- Fix `/notify on` not working after `/notify off` via Telegram (Issue #12)
+  - Handle on/off commands directly in Python listener instead of delegating to shell script
+  - Eliminates subprocess environment issues that prevented flag file creation
+  - Listener now sends confirmation messages directly for reliable feedback
 - Fix touchpad scroll cycling through prompt history instead of conversation history
   - Enable tmux mouse mode for claude-remote sessions
   - Add text selection hint (Option+drag on Mac) to session startup output


### PR DESCRIPTION
## Summary
- Handle `/notify on` and `/notify off` commands directly in Python listener instead of delegating to shell script subprocess
- Eliminates subprocess environment issues that prevented flag file creation
- Listener now sends confirmation messages directly for reliable user feedback
- Add 62 unit tests covering notify on/off toggle scenarios

## Root Cause
The previous implementation delegated `/notify on` and `/notify off` to a shell script via subprocess. The subprocess ran with a sanitized environment (`get_safe_env()`), which could cause the shell script's `send_telegram` function to fail silently when loading config files. Even when the shell script's `touch` command succeeded, the listener didn't verify the flag file was created or send its own confirmation message.

## Fix
Now `/notify on` and `/notify off` are handled directly in Python:
- Flag file is created/deleted using Python's `pathlib` (more reliable)
- Confirmation message sent using the listener's `send_message` function (which we know works)
- Proper error handling with user feedback

## Test plan
- [x] All 93 tests pass
- [x] Test `/notify off` followed by `/notify on` creates flag file correctly
- [x] Test toggle sequence: on -> off -> on maintains correct state
- [x] Test idempotent behavior (multiple on/off calls work)
- [x] Test case insensitivity (ON/OFF/On/Off all work)

Fixes #12