### PR TITLE
fix: dev mode symlinks blocked by script path security validation

### DIFF
--- a/.changeset/0011-dev-mode-symlink-validation.md
+++ b/.changeset/0011-dev-mode-symlink-validation.md
@@ -1,0 +1,10 @@
+---
+"claude-remote-notify": patch
+---
+
+Fix dev mode symlinks blocked by script path security validation
+
+- Allow symlinks within CLAUDE_HOME to point to targets outside (dev mode)
+- Validate symlink location first, then check target's ownership and permissions
+- Target must still be user-owned and not world-writable for security
+- Handle macOS path symlinks (/var -> /private/var) in path comparison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - `format_for_telegram()` function in lib/common.sh for terminal output transformation
 
 ### Fixed
+- Fix dev mode symlinks blocked by security validation (Issue #16)
+  - Allow symlinks within CLAUDE_HOME to point to targets outside (dev mode setup)
+  - Validate symlink location, then check target's ownership and permissions
+  - Target must still be user-owned and not world-writable for security
 - Fix `/notify on` not working after `/notify off` via Telegram (Issue #12)
   - Handle on/off commands directly in Python listener instead of delegating to shell script
   - Eliminates subprocess environment issues that prevented flag file creation


### PR DESCRIPTION
## Summary
- Allow symlinks within CLAUDE_HOME to point to targets outside (dev mode setup)
- Validate symlink location first, then check target's ownership and permissions
- Target must still be user-owned and not world-writable for security
- Handle macOS path symlinks (`/var` → `/private/var`) in path comparison

Closes #16

## Test plan
- [ ] Run `pytest tests/test_security.py -v` - verify all 35 tests pass
- [ ] Set up dev mode with symlinked scripts
- [ ] Send `/notify status` via Telegram - verify no "outside CLAUDE_HOME" error
- [ ] Verify symlink to world-writable target is still rejected