### PR TITLE
feat: accept Topic ID as alternative session identifier

### DIFF
--- a/.changeset/0017-topic-id-session-identifier.md
+++ b/.changeset/0017-topic-id-session-identifier.md
@@ -1,0 +1,5 @@
+---
+"claude-remote-notify": minor
+---
+
+Accept Topic ID as alternative session identifier in CLI. `claude-remote 70` resolves topic ID to session name. Session names take priority over topic IDs when ambiguous.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- Topic ID as alternative session identifier (Issue #27)
+  - `claude-remote 70` resolves topic ID to session name
+  - Session names take priority over topic IDs when ambiguous
+  - Clear errors for unknown or duplicate topic IDs
+  - `resolve_session_identifier()` in lib/common.sh
 - Smart notification context parsing (Issue #25)
   - Extracts natural language text from terminal context (questions, summaries, options, bullets)
   - Omits code blocks, diffs, file paths, and prompt lines

--- a/claude-remote
+++ b/claude-remote
@@ -6,7 +6,7 @@
 # Multi-session support with Telegram Topics
 #
 # Usage:
-#   claude-remote [SESSION_NAME] [OPTIONS]
+#   claude-remote [SESSION | TOPIC_ID] [OPTIONS]
 #
 # Options:
 #   --status        Show status of session(s)
@@ -14,9 +14,14 @@
 #   --list          List all active sessions
 #   --new           Create new session (interactive setup)
 #
+# Arguments:
+#   SESSION         Session name (e.g., myproject)
+#   TOPIC_ID        Numeric Telegram Topic ID (resolves to session)
+#
 # Examples:
 #   claude-remote                  # Start/attach "default" session
 #   claude-remote myproject        # Start/attach "myproject" session
+#   claude-remote 70               # Start session with topic ID 70
 #   claude-remote myproject --kill # Stop myproject session
 #   claude-remote --list           # Show all sessions
 #   claude-remote --new            # Create new session config
@@ -42,6 +47,16 @@ HOOKS_DIR="$CLAUDE_HOME/hooks"
 
 # Ensure directories exist
 mkdir -p "$SESSIONS_DIR" "$PIDS_DIR" "$LOGS_DIR"
+
+# Source shared utilities (resolve symlinks to find actual script location)
+_SCRIPT_PATH="$0"
+[[ "$_SCRIPT_PATH" != */* ]] && _SCRIPT_PATH="$(command -v "$_SCRIPT_PATH" 2>/dev/null || echo "$_SCRIPT_PATH")"
+[ -L "$_SCRIPT_PATH" ] && _SCRIPT_PATH="$(readlink "$_SCRIPT_PATH")"
+SCRIPT_DIR="$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)"
+unset _SCRIPT_PATH
+if [ -f "$SCRIPT_DIR/lib/common.sh" ]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+fi
 
 # -----------------------------------------------------------------------------
 # Helper Functions
@@ -629,7 +644,11 @@ main() {
                 shift
                 ;;
             --help|-h)
-                echo "Usage: claude-remote [SESSION] [OPTIONS]"
+                echo "Usage: claude-remote [SESSION | TOPIC_ID] [OPTIONS]"
+                echo ""
+                echo "Arguments:"
+                echo "  SESSION        Session name (e.g., myproject)"
+                echo "  TOPIC_ID       Numeric Telegram Topic ID (resolves to session)"
                 echo ""
                 echo "Options:"
                 echo "  --status, -s   Show session status"
@@ -641,6 +660,7 @@ main() {
                 echo "Examples:"
                 echo "  claude-remote              # Start 'default' session"
                 echo "  claude-remote myproject    # Start 'myproject' session"
+                echo "  claude-remote 70           # Start session with topic ID 70"
                 echo "  claude-remote --list       # List all sessions"
                 exit 0
                 ;;
@@ -653,7 +673,19 @@ main() {
                 ;;
         esac
     done
-    
+
+    # Resolve session identifier (name or topic ID)
+    if [ "$action" != "list" ] && [ "$action" != "new" ] && [ "$session" != "default" ]; then
+        if type resolve_session_identifier &>/dev/null; then
+            local resolved
+            resolved=$(resolve_session_identifier "$session" "$SESSIONS_DIR") || exit 1
+            if [ "$resolved" != "$session" ]; then
+                info "Resolved topic ID $session → session '$resolved'"
+                session="$resolved"
+            fi
+        fi
+    fi
+
     # Execute action
     case "$action" in
         start)


### PR DESCRIPTION
## Summary

Closes #27

- `claude-remote 70` resolves topic ID 70 to its session name
- Session names always take priority over topic IDs (no ambiguity)
- Clear errors for unknown topic ID and duplicate topic IDs across sessions
- `resolve_session_identifier()` added to `lib/common.sh`
- `common.sh` sourced in `claude-remote` with resolution before action dispatch

## Test plan

- [ ] Run `bash tests/test_common.sh` — 6 new resolution tests pass
- [ ] `claude-remote <topic-id> --status` resolves and shows correct session
- [ ] `claude-remote <session-name>` continues to work unchanged
- [ ] `claude-remote <unknown-numeric>` shows "No session found" error
- [ ] Help text (`claude-remote --help`) shows TOPIC_ID usage