### PR TITLE
feat: cancel pending notification on user input (#31)

### DIFF
--- a/.changeset/0019-cancel-pending-notification.md
+++ b/.changeset/0019-cancel-pending-notification.md
@@ -1,0 +1,5 @@
+---
+"claude-remote-notify": patch
+---
+
+Cancel pending delayed notification when user provides input via Telegram or terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- Cancel pending notification on user input (Issue #31)
+  - Telegram input (text, media, button clicks) cancels pending notification immediately
+  - Terminal input via `UserPromptSubmit` hook cancels pending notification immediately
+  - Canonical `cancel_pending_notification()` in lib/common.sh
+  - Native Python equivalent in telegram-listener.py (shared PID file protocol)
+  - Standalone `cancel-pending-notification.sh` hook for Claude Code
+
 ### Fixed
+- `NOTIFY_DEBOUNCE` config key now included in safe config loading whitelist (Issue #31)
+  - Previously silently dropped when using `load_config_safely()`, always defaulting to 20s
 - Fix /preview doubled response (Issue #29)
   - Remove "Generating preview..." intermediary message from both single-session and multi-session handlers
   - Only 👀 reaction + HTML document sent (one response instead of two)

--- a/hooks/cancel-pending-notification.sh
+++ b/hooks/cancel-pending-notification.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# =============================================================================
+# cancel-pending-notification.sh - Cancel pending delayed Telegram notification
+# =============================================================================
+#
+# Called when user provides input before debounce timer expires.
+# Sources lib/common.sh and delegates to cancel_pending_notification().
+#
+# Usage:
+#   cancel-pending-notification.sh [--session NAME]
+#
+# Environment:
+#   CLAUDE_SESSION - Fallback session name (default: "default")
+#
+# =============================================================================
+
+set -euo pipefail
+
+SESSION_NAME="${CLAUDE_SESSION:-default}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --session|-s)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="${SCRIPT_DIR%/hooks}/lib"
+
+if [ -f "$LIB_DIR/common.sh" ]; then
+    source "$LIB_DIR/common.sh"
+else
+    echo "Error: lib/common.sh not found" >&2
+    exit 1
+fi
+
+cancel_pending_notification "$SESSION_NAME"

--- a/hooks/telegram-notify.sh
+++ b/hooks/telegram-notify.sh
@@ -290,13 +290,7 @@ PENDING_PID="$PENDING_DIR/$SESSION_NAME.pid"
 mkdir -p "$PENDING_DIR"
 
 # Kill previous pending sender if exists
-if [ -f "$PENDING_PID" ]; then
-    OLD_PID=$(cat "$PENDING_PID" 2>/dev/null)
-    if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-        kill "$OLD_PID" 2>/dev/null || true
-    fi
-    rm -f "$PENDING_PID"
-fi
+cancel_pending_notification "$SESSION_NAME" "$CLAUDE_HOME"
 
 # If debounce disabled, send immediately
 if [ "$DEBOUNCE_SECONDS" -eq 0 ] 2>/dev/null; then

--- a/setup-telegram-remote.sh
+++ b/setup-telegram-remote.sh
@@ -192,7 +192,7 @@ install_files() {
     }
 
     # Install hooks
-    for hook in telegram-notify.sh telegram-listener.py telegram-preview.sh remote-notify.sh; do
+    for hook in telegram-notify.sh telegram-listener.py telegram-preview.sh remote-notify.sh cancel-pending-notification.sh; do
         if install_file "$SCRIPT_DIR/hooks/$hook" "$CLAUDE_HOME/hooks/$hook" true; then
             if $DEV_MODE; then
                 success "Linked hooks/$hook"

--- a/tests/test_cancel_hook.sh
+++ b/tests/test_cancel_hook.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# =============================================================================
+# test_cancel_hook.sh - Tests for cancel-pending-notification.sh
+# =============================================================================
+
+set -e
+
+PASS=0
+FAIL=0
+TEST_DIR=$(mktemp -d -t "cancel-hook-test-XXXXXX")
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CANCEL_SCRIPT="$SCRIPT_DIR/hooks/cancel-pending-notification.sh"
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "  ✓ $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    echo "  ✗ $1"
+    [ -n "${2:-}" ] && echo "    $2"
+}
+
+echo "═══════════════════════════════════════════"
+echo "  Cancel Pending Notification Hook Tests"
+echo "═══════════════════════════════════════════"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Test: Script exists and is executable
+# -----------------------------------------------------------------------------
+echo "Script validation:"
+
+if [ -x "$CANCEL_SCRIPT" ]; then
+    pass "Script exists and is executable"
+else
+    fail "Script not found or not executable" "$CANCEL_SCRIPT"
+fi
+
+# -----------------------------------------------------------------------------
+# Test: Exit 0 with no pending notification
+# -----------------------------------------------------------------------------
+echo ""
+echo "No pending notification:"
+
+MOCK_HOME="$TEST_DIR/claude-home"
+mkdir -p "$MOCK_HOME/notifications-pending"
+
+CLAUDE_HOME="$MOCK_HOME" CLAUDE_SESSION="test-session" bash "$CANCEL_SCRIPT" 2>/dev/null
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    pass "Exits 0 when no PID file exists"
+else
+    fail "Should exit 0 when no PID file" "exit code=$EXIT_CODE"
+fi
+
+# -----------------------------------------------------------------------------
+# Test: Kills pending process via --session argument
+# -----------------------------------------------------------------------------
+echo ""
+echo "Kill via --session argument:"
+
+(sleep 30) &
+BG_PID=$!
+echo "$BG_PID" > "$MOCK_HOME/notifications-pending/my-session.pid"
+
+CLAUDE_HOME="$MOCK_HOME" bash "$CANCEL_SCRIPT" --session my-session 2>/dev/null
+EXIT_CODE=$?
+sleep 0.1
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    pass "Exits 0 after cancel"
+else
+    fail "Should exit 0" "exit code=$EXIT_CODE"
+fi
+
+if [ ! -f "$MOCK_HOME/notifications-pending/my-session.pid" ]; then
+    pass "PID file removed"
+else
+    fail "PID file should be removed"
+fi
+
+if ! kill -0 "$BG_PID" 2>/dev/null; then
+    pass "Background process killed"
+else
+    fail "Background process should be killed"
+    kill "$BG_PID" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
+# Test: Uses CLAUDE_SESSION env var as fallback
+# -----------------------------------------------------------------------------
+echo ""
+echo "CLAUDE_SESSION env var fallback:"
+
+(sleep 30) &
+BG_PID=$!
+echo "$BG_PID" > "$MOCK_HOME/notifications-pending/env-session.pid"
+
+CLAUDE_HOME="$MOCK_HOME" CLAUDE_SESSION="env-session" bash "$CANCEL_SCRIPT" 2>/dev/null
+sleep 0.1
+
+if [ ! -f "$MOCK_HOME/notifications-pending/env-session.pid" ]; then
+    pass "PID file removed via CLAUDE_SESSION env var"
+else
+    fail "Should use CLAUDE_SESSION env var"
+fi
+
+if ! kill -0 "$BG_PID" 2>/dev/null; then
+    pass "Process killed via CLAUDE_SESSION env var"
+else
+    fail "Process should be killed"
+    kill "$BG_PID" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
+# Test: --session flag overrides CLAUDE_SESSION
+# -----------------------------------------------------------------------------
+echo ""
+echo "Flag overrides env var:"
+
+(sleep 30) &
+BG_PID=$!
+echo "$BG_PID" > "$MOCK_HOME/notifications-pending/flag-session.pid"
+echo "99999999" > "$MOCK_HOME/notifications-pending/env-session.pid"
+
+CLAUDE_HOME="$MOCK_HOME" CLAUDE_SESSION="env-session" bash "$CANCEL_SCRIPT" --session flag-session 2>/dev/null
+sleep 0.1
+
+if [ ! -f "$MOCK_HOME/notifications-pending/flag-session.pid" ]; then
+    pass "--session flag takes priority"
+else
+    fail "--session flag should take priority"
+fi
+
+# env-session PID file should still exist (untouched)
+if [ -f "$MOCK_HOME/notifications-pending/env-session.pid" ]; then
+    pass "Env var session PID file untouched"
+else
+    fail "Env var session PID file should be untouched"
+fi
+
+kill "$BG_PID" 2>/dev/null || true
+rm -f "$MOCK_HOME/notifications-pending/env-session.pid"
+
+# -----------------------------------------------------------------------------
+# Test: Handles stale PID gracefully
+# -----------------------------------------------------------------------------
+echo ""
+echo "Stale PID handling:"
+
+echo "99999999" > "$MOCK_HOME/notifications-pending/stale-session.pid"
+
+CLAUDE_HOME="$MOCK_HOME" bash "$CANCEL_SCRIPT" --session stale-session 2>/dev/null
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    pass "Exits 0 with stale PID"
+else
+    fail "Should exit 0 with stale PID"
+fi
+
+if [ ! -f "$MOCK_HOME/notifications-pending/stale-session.pid" ]; then
+    pass "Stale PID file cleaned up"
+else
+    fail "Stale PID file should be removed"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo ""
+echo "═══════════════════════════════════════════"
+TOTAL=$((PASS + FAIL))
+echo "  Results: $PASS/$TOTAL passed"
+if [ $FAIL -gt 0 ]; then
+    echo "  $FAIL FAILED"
+    echo "═══════════════════════════════════════════"
+    exit 1
+else
+    echo "  All tests passed!"
+    echo "═══════════════════════════════════════════"
+    exit 0
+fi

--- a/tests/test_cancel_notification.py
+++ b/tests/test_cancel_notification.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for cancel_pending_notification() in telegram-listener.py.
+Tests the Python cancel function and its integration with inject functions.
+"""
+
+import os
+import sys
+import signal
+import tempfile
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import subprocess
+
+import pytest
+
+# Mock the requests module before importing
+mock_requests = MagicMock()
+sys.modules['requests'] = mock_requests
+
+# Load telegram-listener.py as a module
+HOOKS_DIR = Path(__file__).parent.parent / 'hooks'
+spec = importlib.util.spec_from_file_location("telegram_listener", HOOKS_DIR / "telegram-listener.py")
+telegram_listener = importlib.util.module_from_spec(spec)
+sys.modules['telegram_listener'] = telegram_listener
+telegram_listener.__name__ = 'telegram_listener'
+spec.loader.exec_module(telegram_listener)
+
+cancel_pending_notification = telegram_listener.cancel_pending_notification
+
+
+class TestCancelPendingNotification:
+    """Tests for the Python cancel_pending_notification() function."""
+
+    def setup_method(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.pending_dir = self.temp_dir / 'notifications-pending'
+        self.pending_dir.mkdir(parents=True)
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_cancel_with_live_process(self):
+        """Kill a running background process via PID file."""
+        # Spawn a sleep process
+        proc = subprocess.Popen(['sleep', '30'])
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text(str(proc.pid))
+
+        cancel_pending_notification('test-session', self.temp_dir)
+
+        # PID file should be removed
+        assert not pid_file.exists()
+
+        # Process should be terminated
+        proc.wait(timeout=2)
+        assert proc.returncode is not None
+
+    def test_cancel_with_stale_pid(self):
+        """Handle a PID file referencing a dead process."""
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text('99999999')
+
+        cancel_pending_notification('test-session', self.temp_dir)
+
+        assert not pid_file.exists()
+
+    def test_cancel_with_no_pid_file(self):
+        """No-op when PID file does not exist."""
+        # Should not raise
+        cancel_pending_notification('nonexistent', self.temp_dir)
+
+    def test_cancel_with_empty_pid_file(self):
+        """Handle an empty PID file gracefully."""
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text('')
+
+        cancel_pending_notification('test-session', self.temp_dir)
+
+        assert not pid_file.exists()
+
+    def test_cancel_with_corrupt_pid_file(self):
+        """Handle non-numeric PID file content."""
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text('not-a-number')
+
+        cancel_pending_notification('test-session', self.temp_dir)
+
+        assert not pid_file.exists()
+
+    def test_cancel_with_whitespace_pid(self):
+        """Handle PID file with trailing whitespace/newlines."""
+        proc = subprocess.Popen(['sleep', '30'])
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text(f'  {proc.pid}\n')
+
+        cancel_pending_notification('test-session', self.temp_dir)
+
+        assert not pid_file.exists()
+        proc.wait(timeout=2)
+        assert proc.returncode is not None
+
+    def test_cancel_uses_default_claude_home(self):
+        """Falls back to CLAUDE_HOME when no path given."""
+        pid_file = self.pending_dir / 'test-session.pid'
+        pid_file.write_text('99999999')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', self.temp_dir):
+            cancel_pending_notification('test-session')
+
+        assert not pid_file.exists()
+
+    def test_cancel_missing_pending_dir(self):
+        """No-op when notifications-pending directory doesn't exist."""
+        empty_dir = self.temp_dir / 'empty'
+        empty_dir.mkdir()
+
+        # Should not raise even though notifications-pending/ doesn't exist
+        cancel_pending_notification('test-session', empty_dir)
+
+
+class TestInjectCancelsNotification:
+    """Tests that inject functions call cancel_pending_notification."""
+
+    def test_inject_to_tmux_session_cancels(self):
+        """inject_to_tmux_session() cancels pending notification on success."""
+        from telegram_listener import SessionState
+
+        session = SessionState(
+            name='test-session',
+            topic_id='123',
+            tmux_session='claude-test',
+            chat_id='-100123456',
+            bot_token='123:ABC'
+        )
+
+        with patch.object(telegram_listener, 'tmux_session_exists_for', return_value=True), \
+             patch.object(telegram_listener, 'subprocess') as mock_sub, \
+             patch.object(telegram_listener, 'cancel_pending_notification') as mock_cancel:
+            mock_sub.run.return_value = MagicMock(returncode=0)
+            mock_sub.CalledProcessError = subprocess.CalledProcessError
+
+            result = telegram_listener.inject_to_tmux_session(session, 'hello')
+
+            assert result is True
+            mock_cancel.assert_called_once_with('test-session')
+
+    def test_inject_to_tmux_session_no_cancel_on_failure(self):
+        """inject_to_tmux_session() does NOT cancel when injection fails."""
+        from telegram_listener import SessionState
+
+        session = SessionState(
+            name='test-session',
+            topic_id='123',
+            tmux_session='claude-test',
+            chat_id='-100123456',
+            bot_token='123:ABC'
+        )
+
+        with patch.object(telegram_listener, 'tmux_session_exists_for', return_value=False), \
+             patch.object(telegram_listener, 'cancel_pending_notification') as mock_cancel:
+
+            result = telegram_listener.inject_to_tmux_session(session, 'hello')
+
+            assert result is False
+            mock_cancel.assert_not_called()
+
+    def test_inject_to_tmux_cancels(self):
+        """inject_to_tmux() cancels pending notification on success."""
+        with patch.object(telegram_listener, 'tmux_session_exists', return_value=True), \
+             patch.object(telegram_listener, 'subprocess') as mock_sub, \
+             patch.object(telegram_listener, 'cancel_pending_notification') as mock_cancel:
+            mock_sub.run.return_value = MagicMock(returncode=0)
+            mock_sub.CalledProcessError = subprocess.CalledProcessError
+
+            result = telegram_listener.inject_to_tmux('hello')
+
+            assert result is True
+            mock_cancel.assert_called_once()
+
+    def test_inject_to_tmux_no_cancel_on_failure(self):
+        """inject_to_tmux() does NOT cancel when injection fails."""
+        with patch.object(telegram_listener, 'tmux_session_exists', return_value=False), \
+             patch.object(telegram_listener, 'cancel_pending_notification') as mock_cancel:
+
+            result = telegram_listener.inject_to_tmux('hello')
+
+            assert result is False
+            mock_cancel.assert_not_called()


### PR DESCRIPTION
## Summary

- Cancel delayed Telegram notifications when user provides input before debounce timer expires
- Covers both input paths: Telegram messages and direct terminal typing
- DRY architecture: canonical bash function in `lib/common.sh`, native Python equivalent in listener, shared PID file protocol
- Bug fix: `NOTIFY_DEBOUNCE` added to safe config loading whitelist (was silently dropped)

## Changes

| File | Change |
|------|--------|
| `lib/common.sh` | `cancel_pending_notification()` function + `NOTIFY_DEBOUNCE` whitelist fix |
| `hooks/cancel-pending-notification.sh` | NEW — standalone wrapper for Claude Code hook |
| `hooks/telegram-notify.sh` | Refactored inline kill to use canonical cancel function |
| `hooks/telegram-listener.py` | Python cancel function + calls in both inject chokepoints |
| `setup-telegram-remote.sh` | Register new script in install loop |
| `~/.claude/settings.json` | `UserPromptSubmit` hook (user config, not in repo) |

## Test plan

- [x] `test_common.sh`: 7/7 passed (6 new cancel tests)
- [x] `test_cancel_hook.sh`: 11/11 passed (standalone script tests)
- [x] `test_cancel_notification.py`: 12/12 passed (Python cancel + inject integration)
- [x] `test_notify_debounce.sh`: 8/8 passed (regression check)
- [x] All Python tests: 286/286 passed, 0 regressions

Closes #31