### PR TITLE
fix: prevent duplicate message routing in multi-session mode

### DIFF
--- a/.changeset/0020-fix-multi-session-routing.md
+++ b/.changeset/0020-fix-multi-session-routing.md
@@ -1,0 +1,5 @@
+---
+"claude-remote-notify": patch
+---
+
+Fix multi-session Telegram routing: prevent duplicate message processing when old single-session listeners conflict with multi-session listener. Added PID-based startup guard, persistent update deduplication, and cleanup script for old listeners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fix multi-session Telegram routing when old single-session listeners are still running (Issue #33)
+  - PID-based startup guard prevents multiple multi-session listener instances
+  - Persistent update deduplication (`~/.claude/state/listener-offsets.json`) prevents duplicate message injection on restart
+  - Interactive detection and cleanup of old single-session listeners at startup
+  - New `cleanup-old-listeners.sh` script to kill stale single-session listener processes
+  - Fixed `is_process_running()` to correctly treat `PermissionError` as "process exists"
+
 ### Added
 - Cancel pending notification on user input (Issue #31)
   - Telegram input (text, media, button clicks) cancels pending notification immediately

--- a/hooks/cleanup-old-listeners.sh
+++ b/hooks/cleanup-old-listeners.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cleanup-old-listeners.sh - Remove old single-session listener processes
+# =============================================================================
+#
+# Finds and kills old single-session listener processes (telegram-listener.py
+# --session) that conflict with the multi-session listener. Also cleans up
+# stale PID files.
+#
+# Usage:
+#   cleanup-old-listeners.sh
+#
+# The multi-session listener calls this script interactively when it detects
+# old single-session listeners at startup.
+# =============================================================================
+
+set -euo pipefail
+
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+PIDS_DIR="$CLAUDE_HOME/pids"
+
+killed=0
+cleaned=0
+
+echo "Scanning for old single-session listeners..."
+
+# Kill running single-session listener processes
+if [[ -d "$PIDS_DIR" ]]; then
+    for pid_file in "$PIDS_DIR"/listener-*.pid; do
+        [[ -f "$pid_file" ]] || continue
+
+        basename="$(basename "$pid_file")"
+
+        # Skip the multi-session PID file
+        if [[ "$basename" == "listener-multi.pid" ]]; then
+            continue
+        fi
+
+        session_name="${basename#listener-}"
+        session_name="${session_name%.pid}"
+
+        pid="$(cat "$pid_file" 2>/dev/null)" || continue
+        if [[ -z "$pid" ]]; then
+            rm -f "$pid_file"
+            ((cleaned++)) || true
+            continue
+        fi
+
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "  Killing $session_name listener (PID: $pid)"
+            kill "$pid" 2>/dev/null || true
+            ((killed++)) || true
+        fi
+
+        rm -f "$pid_file"
+        ((cleaned++)) || true
+    done
+fi
+
+echo ""
+if [[ $killed -gt 0 ]] || [[ $cleaned -gt 0 ]]; then
+    echo "Cleanup complete: $killed process(es) killed, $cleaned PID file(s) removed"
+else
+    echo "No old listeners found"
+fi

--- a/hooks/telegram-listener.py
+++ b/hooks/telegram-listener.py
@@ -42,6 +42,7 @@ Media Support:
 =============================================================================
 """
 
+import json
 import os
 import sys
 import time
@@ -1525,6 +1526,229 @@ def handle_command(command, from_user, message_id=None):
     return False
 
 # =============================================================================
+# STARTUP GUARD & DEDUPLICATION
+# =============================================================================
+
+# Multi-session mode: only one listener instance can run at a time.
+# Old single-session listeners (telegram-listener.py --session) conflict with
+# the multi-session listener because both long-poll the same Telegram bot API,
+# causing "terminated by other getUpdates request" errors and race conditions
+# where the same message gets processed by multiple listeners.
+
+OFFSET_TRACKING_FILE = CLAUDE_HOME / 'state' / 'listener-offsets.json'
+OFFSET_MAX_TRACKED = 1000
+OFFSET_SAVE_INTERVAL = 100  # save every N updates processed
+
+
+def is_process_running(pid: int) -> bool:
+    """Check if a process with the given PID is running."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        # Process exists but we can't signal it — it's running
+        return True
+    except ProcessLookupError:
+        return False
+    except (OSError, ValueError):
+        return False
+
+
+def check_existing_listener() -> bool:
+    """Check if another multi-session listener is already running.
+
+    Returns True if startup should proceed, False if another instance is running.
+    Cleans up stale PID files automatically.
+    """
+    pid_file = CLAUDE_HOME / 'pids' / 'listener-multi.pid'
+
+    if not pid_file.exists():
+        return True
+
+    try:
+        pid_str = pid_file.read_text().strip()
+        if not pid_str:
+            log_multi("Removing empty listener PID file", "WARN")
+            pid_file.unlink(missing_ok=True)
+            return True
+
+        pid = int(pid_str)
+
+        # Don't block on our own PID (e.g. after restart)
+        if pid == os.getpid():
+            return True
+
+        if is_process_running(pid):
+            log_multi(f"Listener already running (PID: {pid}). Only one instance allowed.", "ERROR")
+            return False
+
+        log_multi(f"Removing stale listener PID file (PID {pid} not running)", "WARN")
+        pid_file.unlink(missing_ok=True)
+        return True
+
+    except (ValueError, OSError) as e:
+        log_multi(f"Corrupt PID file, removing: {e}", "WARN")
+        try:
+            pid_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return True
+
+
+def find_old_single_session_listeners() -> list:
+    """Find running old single-session listener processes.
+
+    Returns list of (pid, session_name) tuples.
+    """
+    old_listeners = []
+    pids_dir = CLAUDE_HOME / 'pids'
+
+    if not pids_dir.exists():
+        return old_listeners
+
+    for pid_file in pids_dir.glob('listener-*.pid'):
+        # Skip the multi-session PID file
+        if pid_file.name == 'listener-multi.pid':
+            continue
+
+        session_name = pid_file.stem.replace('listener-', '')
+        try:
+            pid_str = pid_file.read_text().strip()
+            if pid_str:
+                pid = int(pid_str)
+                if is_process_running(pid):
+                    old_listeners.append((pid, session_name))
+        except (ValueError, OSError):
+            pass
+
+    return old_listeners
+
+
+def prompt_cleanup_old_listeners(old_listeners: list) -> bool:
+    """Prompt user to clean up old single-session listeners.
+
+    Returns True if cleanup was performed or skipped, False on error.
+    """
+    print()
+    log_multi(f"Old single-session listeners detected ({len(old_listeners)}):", "WARN")
+    for pid, name in old_listeners:
+        log_multi(f"  - {name} (PID: {pid})", "WARN")
+    print()
+    log_multi("These conflict with multi-session mode and can cause duplicate message routing.", "WARN")
+    print()
+
+    cleanup_script = CLAUDE_HOME / 'hooks' / 'cleanup-old-listeners.sh'
+    if cleanup_script.exists():
+        print("Run cleanup script? (kills old listeners and cleans up)")
+        print("  1. Yes - Run cleanup now")
+        print("  2. No - Continue without cleanup (manual cleanup needed later)")
+        print()
+
+        try:
+            choice = input("Choice [1/2]: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            choice = '2'
+
+        if choice == '1':
+            log_multi("Running cleanup script...")
+            try:
+                result = subprocess.run(
+                    ['bash', str(cleanup_script)],
+                    capture_output=True, text=True, timeout=30
+                )
+                if result.stdout:
+                    print(result.stdout)
+                if result.returncode == 0:
+                    log_multi("Cleanup completed successfully")
+                else:
+                    log_multi(f"Cleanup script exited with code {result.returncode}", "WARN")
+                    if result.stderr:
+                        log_multi(f"Cleanup stderr: {result.stderr.strip()}", "WARN")
+            except subprocess.TimeoutExpired:
+                log_multi("Cleanup script timed out", "ERROR")
+            except Exception as e:
+                log_multi(f"Error running cleanup: {e}", "ERROR")
+        else:
+            log_multi("Skipping cleanup - continuing with potential conflicts", "WARN")
+    else:
+        log_multi("No cleanup script found. Kill old listeners manually:", "WARN")
+        for pid, name in old_listeners:
+            log_multi(f"  kill {pid}  # {name}", "WARN")
+
+    return True
+
+
+class OffsetTracker:
+    """Tracks processed Telegram update_ids to prevent duplicate processing.
+
+    Persists to disk so deduplication survives listener restarts. Keeps only the
+    last OFFSET_MAX_TRACKED update IDs (FIFO removal of oldest).
+    """
+
+    def __init__(self, filepath: Path = OFFSET_TRACKING_FILE, max_tracked: int = OFFSET_MAX_TRACKED):
+        self.filepath = filepath
+        self.max_tracked = max_tracked
+        self.seen_offsets: list = []
+        self.seen_set: set = set()
+        self.updates_since_save = 0
+        self._load()
+
+    def _load(self):
+        """Load tracked offsets from disk."""
+        if not self.filepath.exists():
+            return
+
+        try:
+            data = json.loads(self.filepath.read_text())
+            offsets = data.get('offsets', [])
+            # Keep only last max_tracked
+            if len(offsets) > self.max_tracked:
+                offsets = offsets[-self.max_tracked:]
+            self.seen_offsets = offsets
+            self.seen_set = set(offsets)
+            log_multi(f"Loaded {len(offsets)} tracked offsets from disk")
+        except (json.JSONDecodeError, OSError) as e:
+            log_multi(f"Could not load offset file: {e}", "WARN")
+            self.seen_offsets = []
+            self.seen_set = set()
+
+    def save(self):
+        """Save tracked offsets to disk."""
+        try:
+            self.filepath.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                'offsets': self.seen_offsets[-self.max_tracked:],
+                'last_saved': int(time.time())
+            }
+            self.filepath.write_text(json.dumps(data))
+            self.updates_since_save = 0
+            log_multi(f"Saved {len(self.seen_offsets)} tracked offsets to disk")
+        except OSError as e:
+            log_multi(f"Could not save offset file: {e}", "WARN")
+
+    def is_duplicate(self, update_id: int) -> bool:
+        """Check if an update_id has been seen before."""
+        return update_id in self.seen_set
+
+    def track(self, update_id: int):
+        """Record an update_id as processed."""
+        if update_id not in self.seen_set:
+            self.seen_offsets.append(update_id)
+            self.seen_set.add(update_id)
+
+            # Rotate if too many
+            if len(self.seen_offsets) > self.max_tracked:
+                removed = self.seen_offsets[:-self.max_tracked]
+                self.seen_offsets = self.seen_offsets[-self.max_tracked:]
+                for r in removed:
+                    self.seen_set.discard(r)
+
+        self.updates_since_save += 1
+        if self.updates_since_save >= OFFSET_SAVE_INTERVAL:
+            self.save()
+
+
+# =============================================================================
 # MAIN LOOP
 # =============================================================================
 
@@ -1969,6 +2193,7 @@ def run_multi_session():
 
     offset = None
     error_count = 0
+    tracker = OffsetTracker()
 
     log_multi("Listening for messages (multi-session mode)...")
 
@@ -1983,7 +2208,15 @@ def run_multi_session():
             error_count = 0
 
             for update in updates:
-                offset = update['update_id'] + 1
+                update_id = update['update_id']
+                offset = update_id + 1
+
+                # Deduplication: skip updates we've already processed
+                if tracker.is_duplicate(update_id):
+                    log_multi(f"Skipping duplicate update {update_id}")
+                    continue
+
+                tracker.track(update_id)
 
                 # Handle callback_query (inline keyboard button clicks)
                 callback_query = update.get('callback_query')
@@ -2128,10 +2361,12 @@ def run_multi_session():
 
         except KeyboardInterrupt:
             log_multi("Interrupted by user")
+            tracker.save()
             return False
         except Exception as e:
             error_count += 1
             log_multi(f"Error in main loop: {e}", "ERROR")
+            tracker.save()
 
             if error_count > 10:
                 log_multi("Too many consecutive errors, triggering restart", "ERROR")
@@ -2141,14 +2376,28 @@ def run_multi_session():
             log_multi(f"Waiting {wait_time}s before retry...", "WARN")
             time.sleep(wait_time)
 
+    tracker.save()
     return False
 
 
 def main_multi():
-    """Entry point for multi-session mode."""
+    """Entry point for multi-session mode.
+
+    Only one multi-session listener can run at a time. This function checks for
+    existing instances and old single-session listeners before starting.
+    """
     log_multi("=" * 60)
-    log_multi("Multi-Session Telegram Listener Starting")
+    log_multi("Multi-Session Telegram Listener Starting (Exclusive Mode)")
     log_multi("=" * 60)
+
+    # Startup guard: prevent multiple instances
+    if not check_existing_listener():
+        sys.exit(1)
+
+    # Check for old single-session listeners that conflict with multi-session mode
+    old_listeners = find_old_single_session_listeners()
+    if old_listeners:
+        prompt_cleanup_old_listeners(old_listeners)
 
     # Write PID file for multi-session mode
     pid_file = CLAUDE_HOME / 'pids' / 'listener-multi.pid'

--- a/tests/test_startup_guard.py
+++ b/tests/test_startup_guard.py
@@ -1,0 +1,343 @@
+"""
+Unit tests for startup guard and offset tracking (deduplication).
+Tests check_existing_listener, find_old_single_session_listeners,
+OffsetTracker, and prompt_cleanup_old_listeners.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import shutil
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch, MagicMock, call
+
+import pytest
+
+# Mock the requests module before importing
+mock_requests = MagicMock()
+sys.modules['requests'] = mock_requests
+
+# Load telegram-listener.py as a module
+HOOKS_DIR = Path(__file__).parent.parent / 'hooks'
+spec = importlib.util.spec_from_file_location("telegram_listener", HOOKS_DIR / "telegram-listener.py")
+telegram_listener = importlib.util.module_from_spec(spec)
+sys.modules['telegram_listener'] = telegram_listener
+telegram_listener.__name__ = 'telegram_listener'
+spec.loader.exec_module(telegram_listener)
+
+# Import what we need
+is_process_running = telegram_listener.is_process_running
+check_existing_listener = telegram_listener.check_existing_listener
+find_old_single_session_listeners = telegram_listener.find_old_single_session_listeners
+prompt_cleanup_old_listeners = telegram_listener.prompt_cleanup_old_listeners
+OffsetTracker = telegram_listener.OffsetTracker
+CLAUDE_HOME = telegram_listener.CLAUDE_HOME
+
+
+@pytest.fixture
+def tmp_claude_home(tmp_path):
+    """Create a temporary CLAUDE_HOME structure."""
+    pids_dir = tmp_path / 'pids'
+    pids_dir.mkdir()
+    state_dir = tmp_path / 'state'
+    state_dir.mkdir()
+    logs_dir = tmp_path / 'logs'
+    logs_dir.mkdir()
+    return tmp_path
+
+
+class TestIsProcessRunning:
+    """Tests for is_process_running."""
+
+    def test_current_process_is_running(self):
+        assert is_process_running(os.getpid()) is True
+
+    def test_nonexistent_pid(self):
+        # Use a very high PID that's unlikely to exist
+        assert is_process_running(99999999) is False
+
+    def test_invalid_pid(self):
+        with patch('os.kill', side_effect=OSError):
+            assert is_process_running(-1) is False
+
+
+class TestCheckExistingListener:
+    """Tests for check_existing_listener."""
+
+    def test_no_pid_file(self, tmp_claude_home):
+        """No PID file means startup should proceed."""
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is True
+
+    def test_stale_pid_file_removed(self, tmp_claude_home):
+        """Stale PID file (dead process) should be removed."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        pid_file.write_text('99999999')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is True
+            assert not pid_file.exists()
+
+    def test_empty_pid_file_removed(self, tmp_claude_home):
+        """Empty PID file should be removed."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        pid_file.write_text('')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is True
+            assert not pid_file.exists()
+
+    def test_own_pid_allowed(self, tmp_claude_home):
+        """Our own PID should not block startup (restart scenario)."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        pid_file.write_text(str(os.getpid()))
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is True
+
+    def test_running_process_blocks(self, tmp_claude_home):
+        """Running process with different PID should block startup."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        # PID 1 (init/launchd) is always running
+        pid_file.write_text('1')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is False
+
+    def test_corrupt_pid_file(self, tmp_claude_home):
+        """Corrupt PID file should be removed and startup allowed."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        pid_file.write_text('not-a-number')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert check_existing_listener() is True
+            assert not pid_file.exists()
+
+
+class TestFindOldSingleSessionListeners:
+    """Tests for find_old_single_session_listeners."""
+
+    def test_no_pids_dir(self, tmp_claude_home):
+        """Missing pids dir returns empty list."""
+        shutil.rmtree(tmp_claude_home / 'pids')
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert find_old_single_session_listeners() == []
+
+    def test_no_old_listeners(self, tmp_claude_home):
+        """No PID files means no old listeners."""
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert find_old_single_session_listeners() == []
+
+    def test_skips_multi_pid(self, tmp_claude_home):
+        """Multi-session PID file should be skipped."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-multi.pid'
+        pid_file.write_text(str(os.getpid()))
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert find_old_single_session_listeners() == []
+
+    def test_finds_running_old_listener(self, tmp_claude_home):
+        """Should find running old single-session listener."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-NotaryGuide.pid'
+        # PID 1 is always running
+        pid_file.write_text('1')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            result = find_old_single_session_listeners()
+            assert len(result) == 1
+            assert result[0] == (1, 'NotaryGuide')
+
+    def test_ignores_dead_old_listener(self, tmp_claude_home):
+        """Dead old listener PID files should be ignored."""
+        pid_file = tmp_claude_home / 'pids' / 'listener-OldSession.pid'
+        pid_file.write_text('99999999')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            assert find_old_single_session_listeners() == []
+
+    def test_multiple_old_listeners(self, tmp_claude_home):
+        """Should find multiple running old listeners."""
+        for name in ['NotaryGuide', 'PleiPlatform']:
+            pid_file = tmp_claude_home / 'pids' / f'listener-{name}.pid'
+            pid_file.write_text('1')
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            result = find_old_single_session_listeners()
+            assert len(result) == 2
+            names = {name for _, name in result}
+            assert names == {'NotaryGuide', 'PleiPlatform'}
+
+
+class TestPromptCleanupOldListeners:
+    """Tests for prompt_cleanup_old_listeners."""
+
+    def test_skip_cleanup(self, tmp_claude_home):
+        """User choosing '2' should skip cleanup."""
+        old_listeners = [(1234, 'TestSession')]
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home), \
+             patch('builtins.input', return_value='2'):
+            # Create a dummy cleanup script
+            hooks_dir = tmp_claude_home / 'hooks'
+            hooks_dir.mkdir(exist_ok=True)
+            script = hooks_dir / 'cleanup-old-listeners.sh'
+            script.write_text('#!/bin/bash\necho done')
+            script.chmod(0o755)
+
+            result = prompt_cleanup_old_listeners(old_listeners)
+            assert result is True
+
+    def test_run_cleanup(self, tmp_claude_home):
+        """User choosing '1' should run cleanup script."""
+        old_listeners = [(1234, 'TestSession')]
+
+        hooks_dir = tmp_claude_home / 'hooks'
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / 'cleanup-old-listeners.sh'
+        script.write_text('#!/bin/bash\necho "Cleanup done"')
+        script.chmod(0o755)
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home), \
+             patch('builtins.input', return_value='1'):
+            result = prompt_cleanup_old_listeners(old_listeners)
+            assert result is True
+
+    def test_eof_defaults_to_skip(self, tmp_claude_home):
+        """EOFError during input should default to skip."""
+        old_listeners = [(1234, 'TestSession')]
+
+        hooks_dir = tmp_claude_home / 'hooks'
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / 'cleanup-old-listeners.sh'
+        script.write_text('#!/bin/bash\necho done')
+        script.chmod(0o755)
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home), \
+             patch('builtins.input', side_effect=EOFError):
+            result = prompt_cleanup_old_listeners(old_listeners)
+            assert result is True
+
+    def test_no_cleanup_script(self, tmp_claude_home):
+        """Missing cleanup script should show manual instructions."""
+        old_listeners = [(1234, 'TestSession')]
+
+        with patch.object(telegram_listener, 'CLAUDE_HOME', tmp_claude_home):
+            result = prompt_cleanup_old_listeners(old_listeners)
+            assert result is True
+
+
+class TestOffsetTracker:
+    """Tests for OffsetTracker (deduplication)."""
+
+    def test_new_tracker_empty(self, tmp_claude_home):
+        """New tracker with no file should be empty."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+        assert not tracker.is_duplicate(123)
+
+    def test_track_and_detect_duplicate(self, tmp_claude_home):
+        """Tracked update should be detected as duplicate."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+
+        tracker.track(100)
+        assert tracker.is_duplicate(100)
+        assert not tracker.is_duplicate(101)
+
+    def test_save_and_reload(self, tmp_claude_home):
+        """Offsets should persist across tracker instances."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+
+        tracker.track(200)
+        tracker.track(201)
+        tracker.save()
+
+        # Reload
+        tracker2 = OffsetTracker(filepath=filepath)
+        assert tracker2.is_duplicate(200)
+        assert tracker2.is_duplicate(201)
+        assert not tracker2.is_duplicate(202)
+
+    def test_rotation(self, tmp_claude_home):
+        """Tracker should rotate old entries when max_tracked is reached."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath, max_tracked=5)
+
+        for i in range(10):
+            tracker.track(i)
+
+        # Oldest entries should have been rotated out
+        assert not tracker.is_duplicate(0)
+        assert not tracker.is_duplicate(4)
+        # Recent entries should still be there
+        assert tracker.is_duplicate(5)
+        assert tracker.is_duplicate(9)
+
+    def test_auto_save_interval(self, tmp_claude_home):
+        """Tracker should auto-save after OFFSET_SAVE_INTERVAL updates."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath, max_tracked=200)
+
+        # Override save interval for testing
+        original_interval = telegram_listener.OFFSET_SAVE_INTERVAL
+        telegram_listener.OFFSET_SAVE_INTERVAL = 5
+
+        try:
+            for i in range(5):
+                tracker.track(i)
+
+            # Should have auto-saved
+            assert filepath.exists()
+            data = json.loads(filepath.read_text())
+            assert len(data['offsets']) == 5
+        finally:
+            telegram_listener.OFFSET_SAVE_INTERVAL = original_interval
+
+    def test_corrupt_file_handled(self, tmp_claude_home):
+        """Corrupt offset file should not crash tracker."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        filepath.write_text('not valid json')
+
+        tracker = OffsetTracker(filepath=filepath)
+        assert not tracker.is_duplicate(100)
+        tracker.track(100)
+        assert tracker.is_duplicate(100)
+
+    def test_save_creates_directory(self, tmp_claude_home):
+        """Save should create state directory if missing."""
+        state_dir = tmp_claude_home / 'state'
+        shutil.rmtree(state_dir)
+
+        filepath = state_dir / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+        tracker.track(100)
+        tracker.save()
+
+        assert filepath.exists()
+
+    def test_duplicate_track_idempotent(self, tmp_claude_home):
+        """Tracking same ID twice should not grow the list."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+
+        tracker.track(100)
+        tracker.track(100)
+        assert len(tracker.seen_offsets) == 1
+
+    def test_save_file_format(self, tmp_claude_home):
+        """Verify the saved JSON structure."""
+        filepath = tmp_claude_home / 'state' / 'listener-offsets.json'
+        tracker = OffsetTracker(filepath=filepath)
+
+        tracker.track(100)
+        tracker.track(200)
+        tracker.save()
+
+        data = json.loads(filepath.read_text())
+        assert 'offsets' in data
+        assert 'last_saved' in data
+        assert data['offsets'] == [100, 200]
+        assert isinstance(data['last_saved'], int)


### PR DESCRIPTION
## Summary
- Add PID-based startup guard to prevent multiple multi-session listener instances from running simultaneously
- Add persistent update deduplication (`~/.claude/state/listener-offsets.json`) to prevent duplicate message injection across restarts
- Detect old single-session listeners at startup with interactive cleanup prompt
- New `cleanup-old-listeners.sh` script to kill stale single-session listener processes
- Fix `is_process_running()` to correctly treat `PermissionError` as "process exists"

Closes #33

## Test plan
- [x] 28 new tests in `test_startup_guard.py` (all passing)
- [x] Full suite: 314 tests passing
- [ ] Start listener with old single-session listeners running — verify cleanup prompt appears
- [ ] Try starting a second listener instance — verify it's blocked with clear error
- [ ] Restart listener mid-processing — verify offset tracking prevents duplicate injection
- [ ] Send messages to different topics with 2+ sessions — verify isolation