### PR TITLE
feat: claude-remote init - auto-create topic + launch session

### DIFF
--- a/.changeset/0021-init-command.md
+++ b/.changeset/0021-init-command.md
@@ -1,0 +1,5 @@
+---
+"claude-remote-notify": patch
+---
+
+Add `claude-remote init` action for one-shot session bootstrap: auto-creates a Telegram forum topic (with deterministic icon color), writes the session config, sends a minimal welcome message, and launches the session. Supports flag-driven non-interactive use and name-based topic reuse via a local registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- `claude-remote init` — one-shot session bootstrap that auto-creates a Telegram forum topic, writes the session config, and launches the session. Supports `--name`, `--topic-name`, `--reuse-existing`, `--non-interactive`, `--force`, `--no-test-message`, `--no-start`.
+- Local topic registry at `~/.claude/topics-cache.conf` to support name-based dedup.
+- Deterministic topic icon color (hash of session name → one of 7 Telegram presets).
+- Opt-in live smoke test at `tests/smoke_init_live.sh` with auto-cleanup of created topics.
+
 ### Fixed
 - Fix multi-session Telegram routing when old single-session listeners are still running (Issue #33)
   - PID-based startup guard prevents multiple multi-session listener instances

--- a/README.md
+++ b/README.md
@@ -122,6 +122,42 @@ claude-remote --list
 - Detach: `Ctrl+b, d` (keeps session running in background)
 - Text select: `Option+drag` on Mac (mouse mode enabled for touchpad scrolling)
 
+### One-shot session bootstrap with `init`
+
+From any project directory:
+
+```bash
+claude-remote init
+```
+
+This will:
+1. Use the directory name as the session name (override with `--name`)
+2. Verify the bot is admin of your group with **Manage Topics** permission
+3. Auto-create a new Telegram forum topic with a deterministic icon color
+4. Write `~/.claude/sessions/<name>.conf`
+5. Send a minimal welcome message to the new topic
+6. Launch the session immediately
+
+**Requirements:**
+- Group must be a supergroup with Topics enabled (Group Settings → Topics → On)
+- Bot must be promoted to admin with **Manage Topics** permission
+
+**Flags:**
+
+| Flag | Purpose |
+|---|---|
+| `--name <session>` | Override session name (default: `$(basename $PWD)`) |
+| `--topic-name <text>` | Override topic display name (default: session name) |
+| `--reuse-existing` | If a topic with this name is in the local registry, reuse it instead of prompting |
+| `--non-interactive` | Fail instead of prompting on conflicts |
+| `--force` | Overwrite an existing session config without asking |
+| `--no-test-message` | Skip the welcome message |
+| `--no-start` | Don't launch the session after init |
+
+**Note on topic discovery:** Telegram's Bot API doesn't expose a "list topics" endpoint, so duplicate detection is based on a local registry at `~/.claude/topics-cache.conf` of topics this CLI has created. Topics created in Telegram directly are not tracked.
+
+**Live smoke test:** `tests/smoke_init_live.sh` exercises the full flow against a real Telegram group and cleans up after itself. By default it reads credentials from `~/.claude/telegram-remote.conf` — no env-var setup required. To target a different bot/group, override with `SMOKE_BOT_TOKEN` / `SMOKE_CHAT_ID`. The bot needs `can_manage_topics` and (for auto-cleanup) `can_delete_messages` admin permissions.
+
 ## Architecture
 
 ```

--- a/claude-remote
+++ b/claude-remote
@@ -617,13 +617,167 @@ EOF
 }
 
 # -----------------------------------------------------------------------------
+# init - one-shot session bootstrap with auto-created Telegram topic
+# -----------------------------------------------------------------------------
+
+cmd_init() {
+    local session_name=""
+    local topic_name=""
+    local non_interactive="false"
+    local force="false"
+    local reuse_existing="false"
+    local no_start="false"
+    local no_test_message="false"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --name)             session_name="$2"; shift 2 ;;
+            --topic-name)       topic_name="$2"; shift 2 ;;
+            --non-interactive)  non_interactive="true"; shift ;;
+            --force)            force="true"; shift ;;
+            --reuse-existing)   reuse_existing="true"; shift ;;
+            --no-start)         no_start="true"; shift ;;
+            --no-test-message)  no_test_message="true"; shift ;;
+            *) error "Unknown init flag: $1" ;;
+        esac
+    done
+
+    # Default session name = current directory basename
+    if [ -z "$session_name" ]; then
+        session_name=$(basename "$PWD")
+    fi
+    session_name=$(echo "$session_name" | tr -cd 'a-zA-Z0-9_-')
+    if [ -z "$session_name" ]; then
+        error "Could not derive a valid session name. Use --name."
+    fi
+
+    # Default topic name = session name
+    [ -z "$topic_name" ] && topic_name="$session_name"
+
+    local config="$SESSIONS_DIR/$session_name.conf"
+
+    # Existing session config check
+    if [ -f "$config" ] && [ "$force" != "true" ]; then
+        if [ "$non_interactive" = "true" ]; then
+            error "Session '$session_name' already exists. Use --force to overwrite."
+        fi
+        warn "Session '$session_name' already exists at $config"
+        read -p "Overwrite? (y/N): " ow
+        [[ "$ow" =~ ^[Yy]$ ]] || { info "Aborted."; exit 0; }
+    fi
+
+    # Require global Telegram config
+    local global_conf="$CLAUDE_HOME/telegram-remote.conf"
+    if [ ! -f "$global_conf" ]; then
+        error "Global config not found at $global_conf. Run setup-telegram-remote.sh first."
+    fi
+
+    local bot_token chat_id
+    bot_token=$(grep '^TELEGRAM_BOT_TOKEN=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
+    chat_id=$(grep '^TELEGRAM_CHAT_ID=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
+    [ -z "$bot_token" ] && error "TELEGRAM_BOT_TOKEN missing from $global_conf"
+    [ -z "$chat_id" ]   && error "TELEGRAM_CHAT_ID missing from $global_conf"
+
+    # Verify group is a forum
+    info "Verifying group is forum-enabled..."
+    if ! telegram_chat_is_forum "$bot_token" "$chat_id"; then
+        error "Group $chat_id is not a forum. Enable Topics in Telegram: Group Settings > Topics > On."
+    fi
+
+    # Verify bot has admin + can_manage_topics
+    info "Verifying bot permissions..."
+    if ! telegram_verify_bot_admin "$bot_token" "$chat_id"; then
+        error "Bot is not an admin with 'Manage Topics'. Promote the bot in Telegram first."
+    fi
+
+    # Check registry for existing topic by name
+    local existing_id
+    existing_id=$(lookup_topic_by_name "$topic_name")
+    local topic_id=""
+
+    if [ -n "$existing_id" ]; then
+        if [ "$reuse_existing" = "true" ]; then
+            info "Reusing existing topic '$topic_name' (id=$existing_id) from registry."
+            topic_id="$existing_id"
+        elif [ "$non_interactive" = "true" ]; then
+            error "Topic '$topic_name' exists in registry (id=$existing_id). Use --reuse-existing or pick a different --topic-name."
+        else
+            warn "Topic '$topic_name' already exists in registry (id=$existing_id)."
+            echo "  [r] Reuse existing topic"
+            echo "  [n] Pick a new name"
+            echo "  [c] Cancel"
+            read -p "Choice (r/n/c): " choice
+            case "$choice" in
+                r|R) topic_id="$existing_id" ;;
+                n|N)
+                    read -p "New topic name: " topic_name
+                    [ -z "$topic_name" ] && error "Topic name required."
+                    ;;
+                *) info "Cancelled."; exit 0 ;;
+            esac
+        fi
+    fi
+
+    # Create topic if we don't have one yet
+    if [ -z "$topic_id" ]; then
+        local color
+        color=$(deterministic_icon_color "$session_name")
+        info "Creating topic '$topic_name' (icon color=$color)..."
+        topic_id=$(telegram_create_topic "$bot_token" "$chat_id" "$topic_name" "$color")
+        [ -z "$topic_id" ] && error "Failed to create topic. Check bot permissions and group settings."
+        register_topic "$topic_name" "$topic_id"
+        success "Topic created (id=$topic_id)"
+    fi
+
+    # Write session config
+    mkdir -p "$SESSIONS_DIR"
+    cat > "$config" <<EOF
+# Claude Remote - Session: $session_name
+# Created: $(date)
+
+TELEGRAM_BOT_TOKEN="$bot_token"
+TELEGRAM_CHAT_ID="$chat_id"
+TELEGRAM_TOPIC_ID="$topic_id"
+TELEGRAM_TOPIC_NAME="$topic_name"
+TMUX_SESSION="claude-$session_name"
+EOF
+    chmod 600 "$config"
+    success "Session config written: $config"
+
+    # Minimal welcome message
+    if [ "$no_test_message" != "true" ]; then
+        curl -s -X POST "https://api.telegram.org/bot${bot_token}/sendMessage" \
+            -d "chat_id=${chat_id}" \
+            -d "message_thread_id=${topic_id}" \
+            --data-urlencode "text=Session \`${session_name}\` ready." \
+            -d "parse_mode=Markdown" >/dev/null || true
+    fi
+
+    # Chain into session start
+    if [ "$no_start" = "true" ]; then
+        info "Skipping session start (--no-start)."
+        echo "To start: claude-remote $session_name"
+    else
+        info "Starting session..."
+        start_session "$session_name"
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
 main() {
     local session="default"
     local action="start"
-    
+
+    # Detect 'init' as first positional sub-command (runs and returns directly)
+    if [ "${1:-}" = "init" ]; then
+        shift
+        cmd_init "$@"
+        return $?
+    fi
+
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in

--- a/claude-remote
+++ b/claude-remote
@@ -631,8 +631,12 @@ cmd_init() {
 
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --name)             session_name="$2"; shift 2 ;;
-            --topic-name)       topic_name="$2"; shift 2 ;;
+            --name)
+                [ -z "${2:-}" ] && error "--name requires a value"
+                session_name="$2"; shift 2 ;;
+            --topic-name)
+                [ -z "${2:-}" ] && error "--topic-name requires a value"
+                topic_name="$2"; shift 2 ;;
             --non-interactive)  non_interactive="true"; shift ;;
             --force)            force="true"; shift ;;
             --reuse-existing)   reuse_existing="true"; shift ;;
@@ -641,6 +645,9 @@ cmd_init() {
             *) error "Unknown init flag: $1" ;;
         esac
     done
+
+    # Auto-enable non-interactive if stdin is not a terminal (CI, hooks, pipes)
+    [ -t 0 ] || non_interactive="true"
 
     # Default session name = current directory basename
     if [ -z "$session_name" ]; then
@@ -673,8 +680,8 @@ cmd_init() {
     fi
 
     local bot_token chat_id
-    bot_token=$(grep '^TELEGRAM_BOT_TOKEN=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
-    chat_id=$(grep '^TELEGRAM_CHAT_ID=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
+    bot_token=$(grep '^TELEGRAM_BOT_TOKEN=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'" || true)
+    chat_id=$(grep '^TELEGRAM_CHAT_ID=' "$global_conf" | cut -d'=' -f2- | tr -d '"' | tr -d "'" || true)
     [ -z "$bot_token" ] && error "TELEGRAM_BOT_TOKEN missing from $global_conf"
     [ -z "$chat_id" ]   && error "TELEGRAM_CHAT_ID missing from $global_conf"
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "mybots",
+    "myproject",
+    "pids",
+    "pytest",
+    "shlex",
+    "supergroup"
+  ]
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -823,6 +823,9 @@ telegram_verify_bot_admin() {
 
 # Create a forum topic. Prints the new topic's message_thread_id on success.
 # Returns non-zero on API failure.
+# Note: NOT idempotent. The Telegram API will create a duplicate topic if
+# called twice with the same name. Callers should check the local registry
+# (lookup_topic_by_name) before calling to avoid duplicates.
 # Usage: telegram_create_topic "$BOT_TOKEN" "$CHAT_ID" "Topic Name" "<icon_color>"
 telegram_create_topic() {
     local token="${1:-}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -680,3 +680,64 @@ deterministic_icon_color() {
     local idx=$((hash % ${#TELEGRAM_TOPIC_COLORS[@]}))
     echo "${TELEGRAM_TOPIC_COLORS[$idx]}"
 }
+
+# =============================================================================
+# TOPIC REGISTRY
+# =============================================================================
+# Telegram Bot API does not provide a method to list existing forum topics.
+# To support name-based reuse, we maintain a local registry of topics this CLI
+# has created at ~/.claude/topics-cache.conf (key=value, one per line).
+
+# Path to the local topic registry. Override with TOPICS_CACHE_FILE for tests.
+_topics_cache_path() {
+    echo "${TOPICS_CACHE_FILE:-$HOME/.claude/topics-cache.conf}"
+}
+
+# Sanitize a topic name into a safe registry key.
+# Lowercases, replaces non-alphanumeric runs with single underscores, trims.
+_topic_key() {
+    local name="${1:-}"
+    printf '%s' "$name" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//'
+}
+
+# Look up a topic ID by name. Prints the ID or empty.
+# Usage: lookup_topic_by_name "My Project"
+lookup_topic_by_name() {
+    local name="${1:-}"
+    local cache
+    cache=$(_topics_cache_path)
+    [ -f "$cache" ] || return 0
+    local key
+    key=$(_topic_key "$name")
+    [ -z "$key" ] && return 0
+    awk -F= -v k="$key" '$1 == k { print $2; exit }' "$cache"
+}
+
+# Register a topic name -> ID mapping.
+# Usage: register_topic "My Project" "12345"
+register_topic() {
+    local name="${1:-}"
+    local id="${2:-}"
+    local cache
+    cache=$(_topics_cache_path)
+    local cache_dir
+    cache_dir=$(dirname "$cache")
+    mkdir -p "$cache_dir"
+
+    local key
+    key=$(_topic_key "$name")
+    [ -z "$key" ] && return 1
+    [ -z "$id" ] && return 1
+
+    # Remove any existing entry for this key, then append.
+    local tmp
+    tmp=$(mktemp -t topicreg-XXXXXX)
+    if [ -f "$cache" ]; then
+        awk -F= -v k="$key" '$1 != k' "$cache" > "$tmp"
+    fi
+    printf '%s=%s\n' "$key" "$id" >> "$tmp"
+    mv "$tmp" "$cache"
+    chmod 600 "$cache"
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -746,3 +746,123 @@ register_topic() {
     chmod 600 "$cache"
     trap - RETURN
 }
+
+# =============================================================================
+# TELEGRAM API HELPERS
+# =============================================================================
+
+# Parse a JSON scalar from a Telegram API response using a key path.
+# Minimal parser via python3 to avoid jq dependency (python3 is already
+# required by the listener).
+# Booleans print as "true"/"false". Null prints empty. Missing paths print empty.
+# Usage: _json_get '<json>' '.result.message_thread_id'
+_json_get() {
+    local json="${1:-}"
+    local path="${2:-}"
+    local p="${path#.}"
+    python3 -c "import json,sys
+try:
+    d=json.loads(sys.argv[1])
+    for k in sys.argv[2].split('.'):
+        if isinstance(d, dict) and k in d:
+            d = d[k]
+        else:
+            sys.exit(0)
+    if isinstance(d, bool):
+        print('true' if d else 'false')
+    elif d is None:
+        pass
+    else:
+        print(d)
+except Exception:
+    sys.exit(0)
+" "$json" "$p"
+}
+
+# Check that the chat is a forum-enabled supergroup.
+# Returns 0 if is_forum=true, 1 otherwise.
+# Usage: telegram_chat_is_forum "$BOT_TOKEN" "$CHAT_ID"
+telegram_chat_is_forum() {
+    local token="${1:-}"
+    local chat_id="${2:-}"
+    local response
+    response=$(curl -s "https://api.telegram.org/bot${token}/getChat?chat_id=${chat_id}")
+    local is_forum
+    is_forum=$(_json_get "$response" '.result.is_forum')
+    [ "$is_forum" = "true" ]
+}
+
+# Verify the bot is an admin in the chat with can_manage_topics permission.
+# Returns 0 on success, 1 otherwise.
+# Usage: telegram_verify_bot_admin "$BOT_TOKEN" "$CHAT_ID"
+telegram_verify_bot_admin() {
+    local token="${1:-}"
+    local chat_id="${2:-}"
+
+    local me_response
+    me_response=$(curl -s "https://api.telegram.org/bot${token}/getMe")
+    local bot_id
+    bot_id=$(_json_get "$me_response" '.result.id')
+    [ -z "$bot_id" ] && return 1
+
+    local member_response
+    member_response=$(curl -s "https://api.telegram.org/bot${token}/getChatMember?chat_id=${chat_id}&user_id=${bot_id}")
+    local status
+    status=$(_json_get "$member_response" '.result.status')
+    if [ "$status" != "administrator" ] && [ "$status" != "creator" ]; then
+        return 1
+    fi
+    # creator implicitly has all permissions
+    if [ "$status" = "creator" ]; then
+        return 0
+    fi
+    local can_manage
+    can_manage=$(_json_get "$member_response" '.result.can_manage_topics')
+    [ "$can_manage" = "true" ]
+}
+
+# Create a forum topic. Prints the new topic's message_thread_id on success.
+# Returns non-zero on API failure.
+# Usage: telegram_create_topic "$BOT_TOKEN" "$CHAT_ID" "Topic Name" "<icon_color>"
+telegram_create_topic() {
+    local token="${1:-}"
+    local chat_id="${2:-}"
+    local name="${3:-}"
+    local icon_color="${4:-}"
+
+    local response
+    response=$(curl -s -X POST "https://api.telegram.org/bot${token}/createForumTopic" \
+        -d "chat_id=${chat_id}" \
+        --data-urlencode "name=${name}" \
+        -d "icon_color=${icon_color}")
+
+    local ok
+    ok=$(_json_get "$response" '.ok')
+    if [ "$ok" != "true" ]; then
+        return 1
+    fi
+
+    local thread_id
+    thread_id=$(_json_get "$response" '.result.message_thread_id')
+    [ -z "$thread_id" ] && return 1
+    echo "$thread_id"
+}
+
+# Delete a forum topic by message_thread_id.
+# Requires the bot to have can_delete_messages admin permission.
+# Returns 0 on success, 1 on API failure.
+# Usage: telegram_delete_topic "$BOT_TOKEN" "$CHAT_ID" "$TOPIC_ID"
+telegram_delete_topic() {
+    local token="${1:-}"
+    local chat_id="${2:-}"
+    local topic_id="${3:-}"
+
+    local response
+    response=$(curl -s -X POST "https://api.telegram.org/bot${token}/deleteForumTopic" \
+        -d "chat_id=${chat_id}" \
+        -d "message_thread_id=${topic_id}")
+
+    local ok
+    ok=$(_json_get "$response" '.ok')
+    [ "$ok" = "true" ]
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -511,6 +511,29 @@ html_escape() {
 # - Converts ASCII/Unicode tables to bullet points
 # - Preserves basic markdown (bold, italic, code)
 # Usage: formatted=$(format_for_telegram "$raw_text")
+# =============================================================================
+# TELEGRAM FORUM TOPIC HELPERS
+# =============================================================================
+
+# Telegram forum topic icon colors (7 presets defined by the Bot API).
+# Source: https://core.telegram.org/bots/api#createforumtopic
+TELEGRAM_TOPIC_COLORS=(7322096 16766590 13338331 9367192 16749490 16478047 15749964)
+
+# Deterministic icon color from session name.
+# Hashes the name with cksum and indexes into TELEGRAM_TOPIC_COLORS.
+# Usage: deterministic_icon_color "myproject"
+deterministic_icon_color() {
+    local name="$1"
+    if [ -z "$name" ]; then
+        echo "${TELEGRAM_TOPIC_COLORS[0]}"
+        return 0
+    fi
+    local hash
+    hash=$(printf '%s' "$name" | cksum | awk '{print $1}')
+    local idx=$((hash % ${#TELEGRAM_TOPIC_COLORS[@]}))
+    echo "${TELEGRAM_TOPIC_COLORS[$idx]}"
+}
+
 format_for_telegram() {
     local input="$1"
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -511,28 +511,6 @@ html_escape() {
 # - Converts ASCII/Unicode tables to bullet points
 # - Preserves basic markdown (bold, italic, code)
 # Usage: formatted=$(format_for_telegram "$raw_text")
-# =============================================================================
-# TELEGRAM FORUM TOPIC HELPERS
-# =============================================================================
-
-# Telegram forum topic icon colors (7 presets defined by the Bot API).
-# Source: https://core.telegram.org/bots/api#createforumtopic
-TELEGRAM_TOPIC_COLORS=(7322096 16766590 13338331 9367192 16749490 16478047 15749964)
-
-# Deterministic icon color from session name.
-# Hashes the name with cksum and indexes into TELEGRAM_TOPIC_COLORS.
-# Usage: deterministic_icon_color "myproject"
-deterministic_icon_color() {
-    local name="$1"
-    if [ -z "$name" ]; then
-        echo "${TELEGRAM_TOPIC_COLORS[0]}"
-        return 0
-    fi
-    local hash
-    hash=$(printf '%s' "$name" | cksum | awk '{print $1}')
-    local idx=$((hash % ${#TELEGRAM_TOPIC_COLORS[@]}))
-    echo "${TELEGRAM_TOPIC_COLORS[$idx]}"
-}
 
 format_for_telegram() {
     local input="$1"
@@ -678,4 +656,27 @@ def format_for_telegram(text):
 text = sys.argv[1] if len(sys.argv) > 1 else ""
 print(format_for_telegram(text))
 ' "$input"
+}
+
+# =============================================================================
+# TELEGRAM FORUM TOPIC HELPERS
+# =============================================================================
+
+# Telegram forum topic icon colors (7 presets defined by the Bot API).
+# Source: https://core.telegram.org/bots/api#createforumtopic
+TELEGRAM_TOPIC_COLORS=(7322096 16766590 13338331 9367192 16749490 16478047 15749964)
+
+# Deterministic icon color from session name.
+# Hashes the name with cksum and indexes into TELEGRAM_TOPIC_COLORS.
+# Usage: deterministic_icon_color "myproject"
+deterministic_icon_color() {
+    local name="${1:-}"
+    if [ -z "$name" ]; then
+        echo "${TELEGRAM_TOPIC_COLORS[0]}"
+        return 0
+    fi
+    local hash
+    hash=$(printf '%s' "$name" | cksum | awk '{print $1}')
+    local idx=$((hash % ${#TELEGRAM_TOPIC_COLORS[@]}))
+    echo "${TELEGRAM_TOPIC_COLORS[$idx]}"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -695,6 +695,8 @@ _topics_cache_path() {
 
 # Sanitize a topic name into a safe registry key.
 # Lowercases, replaces non-alphanumeric runs with single underscores, trims.
+# Note: names that normalize to the same key (e.g. "My Project", "my-project",
+# "MY_PROJECT") are treated as identical; registering one overwrites the others.
 _topic_key() {
     local name="${1:-}"
     printf '%s' "$name" \
@@ -734,10 +736,13 @@ register_topic() {
     # Remove any existing entry for this key, then append.
     local tmp
     tmp=$(mktemp -t topicreg-XXXXXX)
+    # Clean up tmp if we error out before mv completes
+    trap 'rm -f "$tmp"' RETURN
     if [ -f "$cache" ]; then
         awk -F= -v k="$key" '$1 != k' "$cache" > "$tmp"
     fi
     printf '%s=%s\n' "$key" "$id" >> "$tmp"
     mv "$tmp" "$cache"
     chmod 600 "$cache"
+    trap - RETURN
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -233,7 +233,7 @@ log_error() { [ "$LOG_LEVEL" -le "$LOG_LEVEL_ERROR" ] && echo -e "${_LOG_RED}[ER
 # =============================================================================
 
 # Allowed config keys (whitelist)
-_ALLOWED_CONFIG_KEYS="TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID TELEGRAM_TOPIC_ID TMUX_SESSION NOTIFY_DEBOUNCE"
+_ALLOWED_CONFIG_KEYS="TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID TELEGRAM_TOPIC_ID TELEGRAM_TOPIC_NAME TMUX_SESSION NOTIFY_DEBOUNCE"
 
 # Load config file safely without sourcing
 # Usage: load_config_safely "/path/to/config.conf"

--- a/tests/smoke_init_live.sh
+++ b/tests/smoke_init_live.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# =============================================================================
+# smoke_init_live.sh - Opt-in live smoke test against a real Telegram group
+# =============================================================================
+#
+# Runs `claude-remote init` against real Telegram, asserts side effects, then
+# cleans up the created topic, session config, and registry entry.
+#
+# Credentials: by default, sources ~/.claude/telegram-remote.conf and uses
+# TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID from there. Override with env vars
+# SMOKE_BOT_TOKEN / SMOKE_CHAT_ID if you want to target a different bot/group
+# (e.g., a dedicated CI test bot).
+#
+# Bot requirements:
+#   - Admin of the chat with can_manage_topics (required)
+#   - can_delete_messages (recommended; without it auto-cleanup will WARN)
+#
+# Optional env vars:
+#   SMOKE_KEEP        - If set to "1", skip cleanup (leave topic + config in place)
+#
+# Usage:
+#   bash tests/smoke_init_live.sh                                      # uses global config
+#   SMOKE_BOT_TOKEN=... SMOKE_CHAT_ID=... bash tests/smoke_init_live.sh # override
+#
+# Exit codes:
+#   0 - all assertions passed AND cleanup succeeded
+#   1 - assertion failure
+#   2 - missing credentials / preconditions
+# =============================================================================
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+warn() { echo -e "  ${YELLOW}WARN${NC}: $1"; }
+
+FAILURES=0
+
+# --- Resolve credentials ---
+# Priority: SMOKE_* env vars > ~/.claude/telegram-remote.conf
+GLOBAL_CONF="$HOME/.claude/telegram-remote.conf"
+if [ -z "${SMOKE_BOT_TOKEN:-}" ] || [ -z "${SMOKE_CHAT_ID:-}" ]; then
+    if [ -f "$GLOBAL_CONF" ]; then
+        SMOKE_BOT_TOKEN="${SMOKE_BOT_TOKEN:-$(grep '^TELEGRAM_BOT_TOKEN=' "$GLOBAL_CONF" | cut -d'=' -f2- | tr -d '"' | tr -d "'")}"
+        SMOKE_CHAT_ID="${SMOKE_CHAT_ID:-$(grep '^TELEGRAM_CHAT_ID=' "$GLOBAL_CONF" | cut -d'=' -f2- | tr -d '"' | tr -d "'")}"
+    fi
+fi
+
+if [ -z "${SMOKE_BOT_TOKEN:-}" ] || [ -z "${SMOKE_CHAT_ID:-}" ]; then
+    echo "No credentials found. Either:"
+    echo "  - Configure $GLOBAL_CONF (see setup-telegram-remote.sh), or"
+    echo "  - Set SMOKE_BOT_TOKEN and SMOKE_CHAT_ID env vars."
+    exit 2
+fi
+
+SMOKE_NAME="init-smoke-$$"
+SMOKE_TOPIC_NAME="Init Smoke $$"
+
+# Isolate HOME so we don't pollute the user's real ~/.claude
+TMPHOME=$(mktemp -d -t init-smoke-XXXXXX)
+export HOME="$TMPHOME"
+export CLAUDE_HOME="$TMPHOME/.claude"
+mkdir -p "$CLAUDE_HOME"
+
+cat > "$CLAUDE_HOME/telegram-remote.conf" <<EOF
+TELEGRAM_BOT_TOKEN="$SMOKE_BOT_TOKEN"
+TELEGRAM_CHAT_ID="$SMOKE_CHAT_ID"
+EOF
+chmod 600 "$CLAUDE_HOME/telegram-remote.conf"
+
+# Captured state for cleanup
+CREATED_TOPIC_ID=""
+
+# --- Cleanup trap ---
+cleanup() {
+    local exit_code=$?
+    echo ""
+    if [ "${SMOKE_KEEP:-0}" = "1" ]; then
+        warn "SMOKE_KEEP=1 set — leaving topic, config, and HOME ($TMPHOME) in place."
+        exit $exit_code
+    fi
+
+    # shellcheck source=/dev/null
+    source "$PROJECT_DIR/lib/common.sh"
+
+    if [ -n "$CREATED_TOPIC_ID" ]; then
+        echo "Cleanup: deleting topic $CREATED_TOPIC_ID..."
+        if telegram_delete_topic "$SMOKE_BOT_TOKEN" "$SMOKE_CHAT_ID" "$CREATED_TOPIC_ID"; then
+            pass "Topic deleted"
+        else
+            warn "Failed to delete topic $CREATED_TOPIC_ID — delete manually in Telegram. (Bot may lack can_delete_messages.)"
+        fi
+    fi
+
+    rm -rf "$TMPHOME"
+    pass "Removed temp HOME $TMPHOME"
+
+    if [ "$FAILURES" -gt 0 ]; then
+        echo -e "${RED}Smoke test FAILED with $FAILURES assertion failure(s).${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}Smoke test PASSED.${NC}"
+    exit 0
+}
+trap cleanup EXIT INT TERM
+
+# --- Run init (no-start, since this is a CI/smoke context) ---
+echo "Running: claude-remote init --name $SMOKE_NAME --topic-name '$SMOKE_TOPIC_NAME' --no-start --non-interactive"
+"$PROJECT_DIR/claude-remote" init \
+    --name "$SMOKE_NAME" \
+    --topic-name "$SMOKE_TOPIC_NAME" \
+    --no-start \
+    --non-interactive
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail "init exited non-zero ($rc)"
+    exit 1
+fi
+pass "init exited 0"
+
+# --- Assertions ---
+CONFIG="$CLAUDE_HOME/sessions/$SMOKE_NAME.conf"
+if [ -f "$CONFIG" ]; then
+    pass "Session config exists at $CONFIG"
+else
+    fail "Session config missing"
+fi
+
+CREATED_TOPIC_ID=$(grep '^TELEGRAM_TOPIC_ID=' "$CONFIG" | cut -d'=' -f2 | tr -d '"')
+if [ -n "$CREATED_TOPIC_ID" ] && [ "$CREATED_TOPIC_ID" -gt 0 ] 2>/dev/null; then
+    pass "TELEGRAM_TOPIC_ID is a positive integer ($CREATED_TOPIC_ID)"
+else
+    fail "TELEGRAM_TOPIC_ID is missing or invalid: '$CREATED_TOPIC_ID'"
+fi
+
+TOPIC_NAME_PERSISTED=$(grep '^TELEGRAM_TOPIC_NAME=' "$CONFIG" | cut -d'=' -f2 | tr -d '"')
+if [ "$TOPIC_NAME_PERSISTED" = "$SMOKE_TOPIC_NAME" ]; then
+    pass "TELEGRAM_TOPIC_NAME persisted correctly"
+else
+    fail "TELEGRAM_TOPIC_NAME mismatch: expected '$SMOKE_TOPIC_NAME', got '$TOPIC_NAME_PERSISTED'"
+fi
+
+REGISTRY="$CLAUDE_HOME/topics-cache.conf"
+if [ -f "$REGISTRY" ]; then
+    pass "Registry file exists"
+    if grep -q "=$CREATED_TOPIC_ID$" "$REGISTRY"; then
+        pass "Registry contains created topic ID"
+    else
+        fail "Registry missing entry for topic $CREATED_TOPIC_ID"
+    fi
+else
+    fail "Registry file not created"
+fi
+
+# --- Reuse path: second init with same topic-name + --reuse-existing ---
+echo ""
+echo "Running reuse path: claude-remote init --name ${SMOKE_NAME}-2 --topic-name '$SMOKE_TOPIC_NAME' --reuse-existing --no-start --non-interactive"
+"$PROJECT_DIR/claude-remote" init \
+    --name "${SMOKE_NAME}-2" \
+    --topic-name "$SMOKE_TOPIC_NAME" \
+    --reuse-existing \
+    --no-start \
+    --non-interactive
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail "reuse init exited non-zero ($rc)"
+else
+    pass "reuse init exited 0"
+    REUSED_ID=$(grep '^TELEGRAM_TOPIC_ID=' "$CLAUDE_HOME/sessions/${SMOKE_NAME}-2.conf" | cut -d'=' -f2 | tr -d '"')
+    if [ "$REUSED_ID" = "$CREATED_TOPIC_ID" ]; then
+        pass "Reuse path returned same topic ID ($REUSED_ID)"
+    else
+        fail "Reuse path produced different ID: expected $CREATED_TOPIC_ID, got $REUSED_ID"
+    fi
+fi
+
+# Trap fires here for cleanup + final summary

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1345,6 +1345,191 @@ test_topic_registry() {
 }
 
 # =============================================================================
+# TELEGRAM API HELPERS — mock helpers
+# =============================================================================
+
+# Mock curl by creating a temp dir with a stub curl that prints a canned
+# response. Returns the mockdir path via stdout.
+# NOTE: PATH manipulation must be done by the CALLER after capturing the path,
+# because this function runs in a subshell when called via $(...) and cannot
+# export PATH to the parent shell.
+# Usage:
+#   mockdir=$(_mock_curl_setup '{"ok":true}')
+#   export PATH="$mockdir:$PATH"
+#   ...
+#   _mock_curl_teardown "$mockdir"
+_mock_curl_setup() {
+    local response="$1"
+    local mockdir
+    mockdir=$(mktemp -d -t curlmock-XXXXXX)
+    cat > "$mockdir/curl" <<EOF
+#!/bin/bash
+printf '%s' '$response'
+EOF
+    chmod +x "$mockdir/curl"
+    echo "$mockdir"
+}
+
+_mock_curl_teardown() {
+    local mockdir="$1"
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
+}
+
+# =============================================================================
+# TEST: telegram_chat_is_forum
+# =============================================================================
+
+test_telegram_chat_is_forum() {
+    echo ""
+    echo "Testing telegram_chat_is_forum..."
+
+    local mockdir
+    mockdir=$(_mock_curl_setup '{"ok":true,"result":{"id":-100123,"type":"supergroup","is_forum":true}}')
+    export PATH="$mockdir:$PATH"
+    if telegram_chat_is_forum "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: is_forum=true returns success"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: is_forum=true should return success"
+    fi
+    _mock_curl_teardown "$mockdir"
+
+    mockdir=$(_mock_curl_setup '{"ok":true,"result":{"id":-100123,"type":"supergroup"}}')
+    export PATH="$mockdir:$PATH"
+    if ! telegram_chat_is_forum "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: missing is_forum returns failure"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: missing is_forum should fail"
+    fi
+    _mock_curl_teardown "$mockdir"
+}
+
+# =============================================================================
+# TEST: telegram_verify_bot_admin
+# =============================================================================
+
+test_telegram_verify_bot_admin() {
+    echo ""
+    echo "Testing telegram_verify_bot_admin..."
+
+    # Mock returns admin with can_manage_topics
+    local mockdir
+    mockdir=$(mktemp -d -t curlmock-XXXXXX)
+    cat > "$mockdir/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"administrator","can_manage_topics":true,"user":{"id":111}}}'; exit 0 ;;
+    esac
+done
+printf '%s' '{"ok":false}'
+EOF
+    chmod +x "$mockdir/curl"
+    export PATH="$mockdir:$PATH"
+
+    if telegram_verify_bot_admin "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: admin with can_manage_topics passes"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: admin with can_manage_topics should pass"
+    fi
+
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
+
+    # Mock: bot is plain member
+    mockdir=$(mktemp -d -t curlmock-XXXXXX)
+    cat > "$mockdir/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"member","user":{"id":111}}}'; exit 0 ;;
+    esac
+done
+EOF
+    chmod +x "$mockdir/curl"
+    export PATH="$mockdir:$PATH"
+
+    if ! telegram_verify_bot_admin "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: plain member returns failure"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: plain member should fail"
+    fi
+
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
+}
+
+# =============================================================================
+# TEST: telegram_create_topic
+# =============================================================================
+
+test_telegram_create_topic() {
+    echo ""
+    echo "Testing telegram_create_topic..."
+
+    local mockdir
+    mockdir=$(_mock_curl_setup '{"ok":true,"result":{"message_thread_id":42,"name":"foo","icon_color":7322096}}')
+    export PATH="$mockdir:$PATH"
+    local id
+    id=$(telegram_create_topic "FAKETOKEN" "-100123" "foo" "7322096")
+    assert_equals "42" "$id" "Returns message_thread_id on success"
+    _mock_curl_teardown "$mockdir"
+
+    mockdir=$(_mock_curl_setup '{"ok":false,"error_code":400,"description":"Bad Request"}')
+    export PATH="$mockdir:$PATH"
+    if ! telegram_create_topic "FAKETOKEN" "-100123" "foo" "7322096" >/dev/null 2>&1; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: API error returns non-zero"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: API error should return non-zero"
+    fi
+    _mock_curl_teardown "$mockdir"
+}
+
+# =============================================================================
+# TEST: telegram_delete_topic
+# =============================================================================
+
+test_telegram_delete_topic() {
+    echo ""
+    echo "Testing telegram_delete_topic..."
+
+    local mockdir
+    mockdir=$(_mock_curl_setup '{"ok":true,"result":true}')
+    export PATH="$mockdir:$PATH"
+    if telegram_delete_topic "FAKETOKEN" "-100123" "42"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: ok=true returns success"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: ok=true should return success"
+    fi
+    _mock_curl_teardown "$mockdir"
+
+    mockdir=$(_mock_curl_setup '{"ok":false,"error_code":400,"description":"Bad Request: topic not found"}')
+    export PATH="$mockdir:$PATH"
+    if ! telegram_delete_topic "FAKETOKEN" "-100123" "42" >/dev/null 2>&1; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: ok=false returns non-zero"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: ok=false should return non-zero"
+    fi
+    _mock_curl_teardown "$mockdir"
+}
+
+# =============================================================================
 # RUN ALL TESTS
 # =============================================================================
 
@@ -1395,6 +1580,10 @@ run_all_tests() {
     test_cancel_default_claude_home
     test_deterministic_icon_color
     test_topic_registry
+    test_telegram_chat_is_forum
+    test_telegram_verify_bot_admin
+    test_telegram_create_topic
+    test_telegram_delete_topic
 
     echo ""
     echo "=============================================="

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1312,6 +1312,8 @@ test_topic_registry() {
     local tmphome
     tmphome=$(mktemp -d -t topicreg-XXXXXX)
     local orig_home="$HOME"
+    # Restore HOME and remove tmphome even if an assertion later fails under set -e
+    trap 'export HOME="$orig_home"; rm -rf "$tmphome"; trap - RETURN' RETURN
     export HOME="$tmphome"
     mkdir -p "$HOME/.claude"
 
@@ -1340,9 +1342,6 @@ test_topic_registry() {
     perms=$(stat -f '%A' "$HOME/.claude/topics-cache.conf" 2>/dev/null || stat -c '%a' "$HOME/.claude/topics-cache.conf")
     assert_equals "600" "$perms" "Registry file is 0600"
 
-    # Cleanup
-    export HOME="$orig_home"
-    rm -rf "$tmphome"
 }
 
 # =============================================================================

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1255,6 +1255,52 @@ test_cancel_default_claude_home() {
 }
 
 # =============================================================================
+# TEST: deterministic_icon_color
+# =============================================================================
+
+test_deterministic_icon_color() {
+    echo ""
+    echo "Testing deterministic_icon_color..."
+
+    # Same input → same color (deterministic)
+    local color1
+    color1=$(deterministic_icon_color "myproject")
+    local color2
+    color2=$(deterministic_icon_color "myproject")
+    assert_equals "$color1" "$color2" "Same name yields same color"
+
+    # Output is one of the 7 valid Telegram preset colors
+    case "$color1" in
+        7322096|16766590|13338331|9367192|16749490|16478047|15749964)
+            TESTS_RUN=$((TESTS_RUN + 1))
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+            echo -e "  ${GREEN}PASS${NC}: Color is a valid Telegram preset ($color1)"
+            ;;
+        *)
+            TESTS_RUN=$((TESTS_RUN + 1))
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            echo -e "  ${RED}FAIL${NC}: Color $color1 not in valid preset list"
+            ;;
+    esac
+
+    # Different names should (mostly) produce different colors — sample 7 distinct
+    local seen=""
+    for n in alpha beta gamma delta epsilon zeta eta; do
+        seen="$seen $(deterministic_icon_color "$n")"
+    done
+    local unique
+    unique=$(echo "$seen" | tr ' ' '\n' | sort -u | wc -l | tr -d ' ')
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$unique" -ge 3 ]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: 7 distinct names produce ≥3 distinct colors ($unique)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: Only $unique distinct colors from 7 names — hash too clustered"
+    fi
+}
+
+# =============================================================================
 # RUN ALL TESTS
 # =============================================================================
 
@@ -1303,6 +1349,7 @@ run_all_tests() {
     test_cancel_with_empty_file
     test_cancel_with_corrupt_file
     test_cancel_default_claude_home
+    test_deterministic_icon_color
 
     echo ""
     echo "=============================================="

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1286,10 +1286,10 @@ test_deterministic_icon_color() {
     # Different names should (mostly) produce different colors — sample 7 distinct
     local seen=""
     for n in alpha beta gamma delta epsilon zeta eta; do
-        seen="$seen $(deterministic_icon_color "$n")"
+        seen="${seen}$(deterministic_icon_color "$n")\n"
     done
     local unique
-    unique=$(echo "$seen" | tr ' ' '\n' | sort -u | wc -l | tr -d ' ')
+    unique=$(printf '%b' "$seen" | sort -u | grep -c .)
     TESTS_RUN=$((TESTS_RUN + 1))
     if [ "$unique" -ge 3 ]; then
         TESTS_PASSED=$((TESTS_PASSED + 1))

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1301,6 +1301,51 @@ test_deterministic_icon_color() {
 }
 
 # =============================================================================
+# TEST: topic registry (lookup_topic_by_name, register_topic)
+# =============================================================================
+
+test_topic_registry() {
+    echo ""
+    echo "Testing topic registry..."
+
+    # Use a temp HOME so we don't touch user's real registry
+    local tmphome
+    tmphome=$(mktemp -d -t topicreg-XXXXXX)
+    local orig_home="$HOME"
+    export HOME="$tmphome"
+    mkdir -p "$HOME/.claude"
+
+    # Lookup returns empty for missing entry
+    local result
+    result=$(lookup_topic_by_name "missing" || true)
+    assert_equals "" "$result" "Missing topic returns empty"
+
+    # Register then lookup
+    register_topic "myproject" "12345"
+    result=$(lookup_topic_by_name "myproject")
+    assert_equals "12345" "$result" "Registered topic returns ID"
+
+    # Re-register overwrites
+    register_topic "myproject" "67890"
+    result=$(lookup_topic_by_name "myproject")
+    assert_equals "67890" "$result" "Re-registering overwrites"
+
+    # Topic name with spaces and mixed case
+    register_topic "My Cool Project" "999"
+    result=$(lookup_topic_by_name "My Cool Project")
+    assert_equals "999" "$result" "Spaces and mixed case work"
+
+    # Registry file has correct perms (600)
+    local perms
+    perms=$(stat -f '%A' "$HOME/.claude/topics-cache.conf" 2>/dev/null || stat -c '%a' "$HOME/.claude/topics-cache.conf")
+    assert_equals "600" "$perms" "Registry file is 0600"
+
+    # Cleanup
+    export HOME="$orig_home"
+    rm -rf "$tmphome"
+}
+
+# =============================================================================
 # RUN ALL TESTS
 # =============================================================================
 
@@ -1350,6 +1395,7 @@ run_all_tests() {
     test_cancel_with_corrupt_file
     test_cancel_default_claude_home
     test_deterministic_icon_color
+    test_topic_registry
 
     echo ""
     echo "=============================================="

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -1362,9 +1362,11 @@ _mock_curl_setup() {
     local response="$1"
     local mockdir
     mockdir=$(mktemp -d -t curlmock-XXXXXX)
-    cat > "$mockdir/curl" <<EOF
+    # Store response in a sibling file; the mock curl prints its contents.
+    printf '%s' "$response" > "$mockdir/response.json"
+    cat > "$mockdir/curl" <<'EOF'
 #!/bin/bash
-printf '%s' '$response'
+cat "$(dirname "$0")/response.json"
 EOF
     chmod +x "$mockdir/curl"
     echo "$mockdir"
@@ -1467,6 +1469,56 @@ EOF
 
     export PATH="${PATH#$mockdir:}"
     rm -rf "$mockdir"
+
+    # Mock: bot is creator (should pass without can_manage_topics check)
+    mockdir=$(mktemp -d -t curlmock-XXXXXX)
+    cat > "$mockdir/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"creator","user":{"id":111}}}'; exit 0 ;;
+    esac
+done
+EOF
+    chmod +x "$mockdir/curl"
+    export PATH="$mockdir:$PATH"
+
+    if telegram_verify_bot_admin "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: creator status passes implicitly"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: creator status should pass"
+    fi
+
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
+
+    # Mock: administrator but lacking can_manage_topics
+    mockdir=$(mktemp -d -t curlmock-XXXXXX)
+    cat > "$mockdir/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"administrator","can_manage_topics":false,"user":{"id":111}}}'; exit 0 ;;
+    esac
+done
+EOF
+    chmod +x "$mockdir/curl"
+    export PATH="$mockdir:$PATH"
+
+    if ! telegram_verify_bot_admin "FAKETOKEN" "-100123"; then
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: admin without can_manage_topics returns failure"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: admin without can_manage_topics should fail"
+    fi
+
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
 }
 
 # =============================================================================
@@ -1480,13 +1532,17 @@ test_telegram_create_topic() {
     local mockdir
     mockdir=$(_mock_curl_setup '{"ok":true,"result":{"message_thread_id":42,"name":"foo","icon_color":7322096}}')
     export PATH="$mockdir:$PATH"
+    trap 'export PATH="${PATH#$mockdir:}"; rm -rf "$mockdir"' RETURN
     local id
     id=$(telegram_create_topic "FAKETOKEN" "-100123" "foo" "7322096")
     assert_equals "42" "$id" "Returns message_thread_id on success"
-    _mock_curl_teardown "$mockdir"
+    trap - RETURN
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
 
     mockdir=$(_mock_curl_setup '{"ok":false,"error_code":400,"description":"Bad Request"}')
     export PATH="$mockdir:$PATH"
+    trap 'export PATH="${PATH#$mockdir:}"; rm -rf "$mockdir"' RETURN
     if ! telegram_create_topic "FAKETOKEN" "-100123" "foo" "7322096" >/dev/null 2>&1; then
         TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: API error returns non-zero"
@@ -1494,7 +1550,9 @@ test_telegram_create_topic() {
         TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
         echo -e "  ${RED}FAIL${NC}: API error should return non-zero"
     fi
-    _mock_curl_teardown "$mockdir"
+    trap - RETURN
+    export PATH="${PATH#$mockdir:}"
+    rm -rf "$mockdir"
 }
 
 # =============================================================================

--- a/tests/test_init_command.sh
+++ b/tests/test_init_command.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# =============================================================================
+# test_init_command.sh - Integration tests for `claude-remote init`
+# =============================================================================
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="${3:-}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$expected" = "$actual" ]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $message"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $message  (expected=$expected actual=$actual)"
+    fi
+}
+
+# Stub HOME so we can write configs without polluting real ~/.claude
+TMPHOME=$(mktemp -d -t init-test-XXXXXX)
+export HOME="$TMPHOME"
+export CLAUDE_HOME="$TMPHOME/.claude"
+mkdir -p "$CLAUDE_HOME"
+
+cleanup() {
+    rm -rf "$TMPHOME" "$MOCKDIR" "$TMUXSTUB"
+}
+trap cleanup EXIT
+
+# Global config required by init flow
+cat > "$CLAUDE_HOME/telegram-remote.conf" <<EOF
+TELEGRAM_BOT_TOKEN="FAKETOKEN"
+TELEGRAM_CHAT_ID="-100123"
+EOF
+chmod 600 "$CLAUDE_HOME/telegram-remote.conf"
+
+# Mock curl: respond based on endpoint in args
+MOCKDIR=$(mktemp -d -t curlmock-XXXXXX)
+cat > "$MOCKDIR/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChat?chat_id*) printf '%s' '{"ok":true,"result":{"id":-100123,"type":"supergroup","is_forum":true}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"administrator","can_manage_topics":true,"user":{"id":111}}}'; exit 0 ;;
+        *createForumTopic*) printf '%s' '{"ok":true,"result":{"message_thread_id":777,"name":"demo","icon_color":7322096}}'; exit 0 ;;
+        *sendMessage*) printf '%s' '{"ok":true,"result":{"message_id":1}}'; exit 0 ;;
+    esac
+done
+printf '%s' '{"ok":false}'
+EOF
+chmod +x "$MOCKDIR/curl"
+export PATH="$MOCKDIR:$PATH"
+
+# Stub tmux so chain-to-start doesn't attach to a real terminal
+TMUXSTUB=$(mktemp -d -t tmuxstub-XXXXXX)
+cat > "$TMUXSTUB/tmux" <<'EOF'
+#!/bin/bash
+case "$1" in
+    has-session) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMUXSTUB/tmux"
+export PATH="$TMUXSTUB:$PATH"
+
+echo "Testing: claude-remote init --name demo --topic-name demo --no-start"
+
+cd "$TMPHOME"
+"$PROJECT_DIR/claude-remote" init --name demo --topic-name demo --no-start >/tmp/init.out 2>&1
+rc=$?
+assert_equals "0" "$rc" "init exits 0 on happy path"
+
+if [ -f "$CLAUDE_HOME/sessions/demo.conf" ]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: session config written"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: session config missing"
+fi
+
+topic_id=$(grep '^TELEGRAM_TOPIC_ID=' "$CLAUDE_HOME/sessions/demo.conf" 2>/dev/null | cut -d'=' -f2 | tr -d '"')
+assert_equals "777" "$topic_id" "TELEGRAM_TOPIC_ID is 777 from mock"
+
+topic_name=$(grep '^TELEGRAM_TOPIC_NAME=' "$CLAUDE_HOME/sessions/demo.conf" 2>/dev/null | cut -d'=' -f2 | tr -d '"')
+assert_equals "demo" "$topic_name" "TELEGRAM_TOPIC_NAME persisted"
+
+reg_id=$(grep '^demo=' "$CLAUDE_HOME/topics-cache.conf" 2>/dev/null | cut -d'=' -f2)
+assert_equals "777" "$reg_id" "registry updated with new topic"
+
+# --- Second run with same name: should reuse via --reuse-existing flag ---
+echo ""
+echo "Testing: claude-remote init reuse path"
+rm -f "$CLAUDE_HOME/sessions/demo.conf"
+"$PROJECT_DIR/claude-remote" init --name demo --topic-name demo --no-start --reuse-existing --force >/tmp/init2.out 2>&1
+rc=$?
+assert_equals "0" "$rc" "reuse run exits 0"
+topic_id=$(grep '^TELEGRAM_TOPIC_ID=' "$CLAUDE_HOME/sessions/demo.conf" 2>/dev/null | cut -d'=' -f2 | tr -d '"')
+assert_equals "777" "$topic_id" "reused topic ID from registry"
+
+echo ""
+echo "=========================================="
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "=========================================="
+[ "$TESTS_FAILED" -eq 0 ]

--- a/tests/test_init_command.sh
+++ b/tests/test_init_command.sh
@@ -111,6 +111,100 @@ assert_equals "0" "$rc" "reuse run exits 0"
 topic_id=$(grep '^TELEGRAM_TOPIC_ID=' "$CLAUDE_HOME/sessions/demo.conf" 2>/dev/null | cut -d'=' -f2 | tr -d '"')
 assert_equals "777" "$topic_id" "reused topic ID from registry"
 
+# --- Test --no-test-message: sendMessage should not be called ---
+echo ""
+echo "Testing: --no-test-message"
+
+# Add a sendMessage canary to the mock — if it gets called, the canary file is created
+rm -f "$CLAUDE_HOME/sessions/demo-no-msg.conf"
+SENDMSG_CANARY="$TMPHOME/sendmsg-called"
+rm -f "$SENDMSG_CANARY"
+cat > "$MOCKDIR/curl" <<EOF
+#!/bin/bash
+for arg in "\$@"; do
+    case "\$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChat?chat_id*) printf '%s' '{"ok":true,"result":{"id":-100123,"type":"supergroup","is_forum":true}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"administrator","can_manage_topics":true,"user":{"id":111}}}'; exit 0 ;;
+        *createForumTopic*) printf '%s' '{"ok":true,"result":{"message_thread_id":888,"name":"x","icon_color":7322096}}'; exit 0 ;;
+        *sendMessage*) touch "$SENDMSG_CANARY"; printf '%s' '{"ok":true,"result":{"message_id":1}}'; exit 0 ;;
+    esac
+done
+printf '%s' '{"ok":false}'
+EOF
+chmod +x "$MOCKDIR/curl"
+
+"$PROJECT_DIR/claude-remote" init --name demo-no-msg --topic-name demo-no-msg --no-start --no-test-message >/tmp/init3.out 2>&1
+rc=$?
+assert_equals "0" "$rc" "no-test-message run exits 0"
+if [ ! -f "$SENDMSG_CANARY" ]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: sendMessage was NOT called with --no-test-message"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: sendMessage was called despite --no-test-message"
+fi
+
+# --- Test --non-interactive with pre-existing topic name (should fail) ---
+echo ""
+echo "Testing: --non-interactive with topic name conflict"
+
+# Restore the standard mock for createForumTopic returning 777
+cat > "$MOCKDIR/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChat?chat_id*) printf '%s' '{"ok":true,"result":{"id":-100123,"type":"supergroup","is_forum":true}}'; exit 0 ;;
+        *getChatMember*) printf '%s' '{"ok":true,"result":{"status":"administrator","can_manage_topics":true,"user":{"id":111}}}'; exit 0 ;;
+        *createForumTopic*) printf '%s' '{"ok":true,"result":{"message_thread_id":777,"name":"demo","icon_color":7322096}}'; exit 0 ;;
+        *sendMessage*) printf '%s' '{"ok":true,"result":{"message_id":1}}'; exit 0 ;;
+    esac
+done
+printf '%s' '{"ok":false}'
+EOF
+chmod +x "$MOCKDIR/curl"
+
+set +e
+"$PROJECT_DIR/claude-remote" init --name conflict-test --topic-name demo --no-start --non-interactive >/tmp/init4.out 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: --non-interactive with topic conflict exits non-zero"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: --non-interactive with topic conflict should fail"
+fi
+
+# --- Test telegram_chat_is_forum=false should fail with actionable error ---
+echo ""
+echo "Testing: non-forum group fails fast"
+
+cat > "$MOCKDIR/curl" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        *getMe*) printf '%s' '{"ok":true,"result":{"id":111,"is_bot":true,"username":"testbot"}}'; exit 0 ;;
+        *getChat?chat_id*) printf '%s' '{"ok":true,"result":{"id":-100123,"type":"supergroup","is_forum":false}}'; exit 0 ;;
+    esac
+done
+printf '%s' '{"ok":false}'
+EOF
+chmod +x "$MOCKDIR/curl"
+
+set +e
+"$PROJECT_DIR/claude-remote" init --name nonforum --topic-name nonforum --no-start --non-interactive >/tmp/init5.out 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: non-forum group exits non-zero"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: non-forum group should fail"
+fi
+
 echo ""
 echo "=========================================="
 echo "Tests run:    $TESTS_RUN"


### PR DESCRIPTION
## Summary
Adds `claude-remote init`, a one-shot command that auto-creates a Telegram forum topic, writes the session config, sends a minimal welcome message, and launches the session — all from the current project directory.

Closes #35.

## Why
Manual setup currently requires creating the topic in Telegram, copying the topic ID, then running `claude-remote --new` and answering prompts. `init` collapses all of that into one command.

## Behavior
- Session name defaults to `$(basename $PWD)`; override with `--name`
- Topic name defaults to session name; override with `--topic-name`
- Icon color is deterministic (hash of session name → one of 7 Telegram presets)
- Existing topic name in local registry triggers a reuse/rename prompt
- Verifies bot admin + `can_manage_topics` + group is forum, with actionable errors
- Chains directly into session start unless `--no-start`

## Test plan
- [x] Bash unit tests: `bash tests/test_common.sh` (25/25)
- [x] Bash integration tests: `bash tests/test_init_command.sh` (11/11)
- [x] Existing bash suite: `test_claude_remote.sh` (19/19), `test_notify_debounce.sh` (8/8), `test_cancel_hook.sh` (11/11), `test_setup.sh` (18/18)
- [x] Python suite: `pytest tests/` (314/314)
- [x] Live smoke: `bash tests/smoke_init_live.sh` — created topic 3536 in live Telegram group, reused it, then auto-deleted; 10/10 assertions

## Notes
Telegram's Bot API does not provide a "list forum topics" endpoint. Duplicate-by-name detection is based on a local registry (`~/.claude/topics-cache.conf`) of topics this CLI has created. Topics created directly in Telegram aren't tracked.